### PR TITLE
Minor fix & Freescout Module Compatibility

### DIFF
--- a/Database/Migrations/2026_02_17_000001_fix_calendar_items_boolean_defaults.php
+++ b/Database/Migrations/2026_02_17_000001_fix_calendar_items_boolean_defaults.php
@@ -6,16 +6,20 @@ use Illuminate\Support\Facades\DB;
 /**
  * Hardening migration.
  *
- * Some environments (especially Postgres) will throw a NOT NULL violation if an INSERT into
- * calendar_items omits the is_private column, because the original migration defined the column
- * as NOT NULL but without a DEFAULT.
+ * Some environments (especially PostgreSQL) can throw a NOT NULL violation if an INSERT into
+ * calendar_items omits boolean columns that are NOT NULL but have no DEFAULT.
  *
  * This migration:
  *  - Backfills any existing NULLs to false
- *  - Ensures sensible DEFAULTs for booleans
- *  - Re-applies NOT NULL for safety (Postgres)
+ *  - Ensures sensible DEFAULTs for booleans (PostgreSQL)
+ *  - Re-applies NOT NULL for safety (PostgreSQL)
  */
 class FixCalendarItemsBooleanDefaults extends Migration {
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
 	public function up() {
 		$driver = DB::getDriverName();
 
@@ -34,8 +38,14 @@ class FixCalendarItemsBooleanDefaults extends Migration {
 		}
 	}
 
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
 	public function down() {
 		$driver = DB::getDriverName();
+
 		if ( $driver === 'pgsql' ) {
 			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private DROP DEFAULT" );
 			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day DROP DEFAULT" );

--- a/Database/Migrations/2026_02_17_000001_fix_calendar_items_boolean_defaults.php
+++ b/Database/Migrations/2026_02_17_000001_fix_calendar_items_boolean_defaults.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Hardening migration.
+ *
+ * Some environments (especially Postgres) will throw a NOT NULL violation if an INSERT into
+ * calendar_items omits the is_private column, because the original migration defined the column
+ * as NOT NULL but without a DEFAULT.
+ *
+ * This migration:
+ *  - Backfills any existing NULLs to false
+ *  - Ensures sensible DEFAULTs for booleans
+ *  - Re-applies NOT NULL for safety (Postgres)
+ */
+class FixCalendarItemsBooleanDefaults extends Migration {
+	public function up() {
+		$driver = DB::getDriverName();
+
+		if ( $driver === 'pgsql' ) {
+			DB::statement( "UPDATE calendar_items SET is_private = false WHERE is_private IS NULL" );
+			DB::statement( "UPDATE calendar_items SET is_all_day = false WHERE is_all_day IS NULL" );
+			DB::statement( "UPDATE calendar_items SET is_read_only = false WHERE is_read_only IS NULL" );
+
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private SET DEFAULT false" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day SET DEFAULT false" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only SET DEFAULT false" );
+
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private SET NOT NULL" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day SET NOT NULL" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only SET NOT NULL" );
+		}
+	}
+
+	public function down() {
+		$driver = DB::getDriverName();
+		if ( $driver === 'pgsql' ) {
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private DROP DEFAULT" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day DROP DEFAULT" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only DROP DEFAULT" );
+		}
+	}
+}

--- a/Database/Migrations/2026_02_17_000001_fix_calendar_items_boolean_defaults.php
+++ b/Database/Migrations/2026_02_17_000001_fix_calendar_items_boolean_defaults.php
@@ -3,53 +3,45 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-/**
- * Hardening migration.
- *
- * Some environments (especially PostgreSQL) can throw a NOT NULL violation if an INSERT into
- * calendar_items omits boolean columns that are NOT NULL but have no DEFAULT.
- *
- * This migration:
- *  - Backfills any existing NULLs to false
- *  - Ensures sensible DEFAULTs for booleans (PostgreSQL)
- *  - Re-applies NOT NULL for safety (PostgreSQL)
- */
 class FixCalendarItemsBooleanDefaults extends Migration {
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up() {
-		$driver = DB::getDriverName();
+		/**
+		 * Run the migrations.
+		 *
+		 * @return void
+		 */
+		public function up() {
+				$driver = DB::getDriverName();
 
-		if ( $driver === 'pgsql' ) {
-			DB::statement( "UPDATE calendar_items SET is_private = false WHERE is_private IS NULL" );
-			DB::statement( "UPDATE calendar_items SET is_all_day = false WHERE is_all_day IS NULL" );
-			DB::statement( "UPDATE calendar_items SET is_read_only = false WHERE is_read_only IS NULL" );
+				if ( $driver === 'pgsql' ) {
+						// Backfill existing NULLs.
+						DB::statement( "UPDATE calendar_items SET is_private = false WHERE is_private IS NULL" );
+						DB::statement( "UPDATE calendar_items SET is_all_day = false WHERE is_all_day IS NULL" );
+						DB::statement( "UPDATE calendar_items SET is_read_only = false WHERE is_read_only IS NULL" );
 
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private SET DEFAULT false" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day SET DEFAULT false" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only SET DEFAULT false" );
+						// Ensure DEFAULTs for inserts.
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private SET DEFAULT false" );
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day SET DEFAULT false" );
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only SET DEFAULT false" );
 
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private SET NOT NULL" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day SET NOT NULL" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only SET NOT NULL" );
+						// Re-apply NOT NULL for safety.
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private SET NOT NULL" );
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day SET NOT NULL" );
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only SET NOT NULL" );
+				}
 		}
-	}
 
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down() {
-		$driver = DB::getDriverName();
+		/**
+		 * Reverse the migrations.
+		 *
+		 * @return void
+		 */
+		public function down() {
+				$driver = DB::getDriverName();
 
-		if ( $driver === 'pgsql' ) {
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private DROP DEFAULT" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day DROP DEFAULT" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only DROP DEFAULT" );
+				if ( $driver === 'pgsql' ) {
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_private DROP DEFAULT" );
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_all_day DROP DEFAULT" );
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN is_read_only DROP DEFAULT" );
+				}
 		}
-	}
 }

--- a/Database/Migrations/2026_02_17_000002_fix_calendar_items_state_default.php
+++ b/Database/Migrations/2026_02_17_000002_fix_calendar_items_state_default.php
@@ -2,44 +2,46 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 
-class FixCalendarItemsStateDefault extends Migration
-{
-    public function up()
-    {
-        // Backfill any NULL states (PostgreSQL can contain NULLs if inserts skipped the field)
-        DB::table('calendar_items')->whereNull('state')->update(['state' => 'active']);
+/**
+ * Hardening migration.
+ *
+ * Some environments (especially PostgreSQL) can contain NULL states if inserts skipped the field.
+ * Ensure existing rows are backfilled and future inserts have a safe default.
+ */
+class FixCalendarItemsStateDefault extends Migration {
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		// Backfill any NULL states.
+		DB::table( 'calendar_items' )->whereNull( 'state' )->update( [ 'state' => 'active' ] );
 
-        // Set a default at the DB level so future inserts are safe across DB engines
-        Schema::table('calendar_items', function (Blueprint $table) {
-            // Laravel doesn't support altering existing columns without doctrine/dbal.
-            // Use raw SQL below when possible.
-        });
+		$driver = DB::getDriverName();
 
-        $driver = DB::getDriverName();
+		if ( $driver === 'pgsql' ) {
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state SET DEFAULT 'active'" );
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state SET NOT NULL" );
+		} elseif ( $driver === 'mysql' ) {
+			DB::statement( "ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL DEFAULT 'active'" );
+		}
+		// SQLite: altering column defaults isn't reliable without rebuilding the table.
+	}
 
-        if ($driver === 'pgsql') {
-            DB::statement("ALTER TABLE calendar_items ALTER COLUMN state SET DEFAULT 'active'");
-            // Keep NOT NULL as-is; if it was relaxed, enforce it.
-            DB::statement("ALTER TABLE calendar_items ALTER COLUMN state SET NOT NULL");
-        } elseif ($driver === 'mysql') {
-            // MySQL: make sure default exists; keep column NOT NULL
-            DB::statement("ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL DEFAULT 'active'");
-        } elseif ($driver === 'sqlite') {
-            // SQLite can't reliably alter column defaults without table rebuild; backfill is still valuable.
-        }
-    }
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$driver = DB::getDriverName();
 
-    public function down()
-    {
-        $driver = DB::getDriverName();
-
-        if ($driver === 'pgsql') {
-            DB::statement("ALTER TABLE calendar_items ALTER COLUMN state DROP DEFAULT");
-        } elseif ($driver === 'mysql') {
-            DB::statement("ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL");
-        }
-    }
+		if ( $driver === 'pgsql' ) {
+			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state DROP DEFAULT" );
+		} elseif ( $driver === 'mysql' ) {
+			DB::statement( 'ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL' );
+		}
+	}
 }

--- a/Database/Migrations/2026_02_17_000002_fix_calendar_items_state_default.php
+++ b/Database/Migrations/2026_02_17_000002_fix_calendar_items_state_default.php
@@ -3,45 +3,34 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-/**
- * Hardening migration.
- *
- * Some environments (especially PostgreSQL) can contain NULL states if inserts skipped the field.
- * Ensure existing rows are backfilled and future inserts have a safe default.
- */
 class FixCalendarItemsStateDefault extends Migration {
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up() {
-		// Backfill any NULL states.
-		DB::table( 'calendar_items' )->whereNull( 'state' )->update( [ 'state' => 'active' ] );
+		/**
+		 * Run the migrations.
+		 *
+		 * @return void
+		 */
+		public function up() {
+				$driver = DB::getDriverName();
 
-		$driver = DB::getDriverName();
+				if ( $driver === 'pgsql' ) {
+						// Backfill existing NULLs.
+						DB::statement( "UPDATE calendar_items SET state = 'active' WHERE state IS NULL" );
 
-		if ( $driver === 'pgsql' ) {
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state SET DEFAULT 'active'" );
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state SET NOT NULL" );
-		} elseif ( $driver === 'mysql' ) {
-			DB::statement( "ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL DEFAULT 'active'" );
+						// Ensure DEFAULT for inserts.
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state SET DEFAULT 'active'" );
+				}
 		}
-		// SQLite: altering column defaults isn't reliable without rebuilding the table.
-	}
 
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down() {
-		$driver = DB::getDriverName();
+		/**
+		 * Reverse the migrations.
+		 *
+		 * @return void
+		 */
+		public function down() {
+				$driver = DB::getDriverName();
 
-		if ( $driver === 'pgsql' ) {
-			DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state DROP DEFAULT" );
-		} elseif ( $driver === 'mysql' ) {
-			DB::statement( 'ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL' );
+				if ( $driver === 'pgsql' ) {
+						DB::statement( "ALTER TABLE calendar_items ALTER COLUMN state DROP DEFAULT" );
+				}
 		}
-	}
 }

--- a/Database/Migrations/2026_02_17_000002_fix_calendar_items_state_default.php
+++ b/Database/Migrations/2026_02_17_000002_fix_calendar_items_state_default.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+class FixCalendarItemsStateDefault extends Migration
+{
+    public function up()
+    {
+        // Backfill any NULL states (PostgreSQL can contain NULLs if inserts skipped the field)
+        DB::table('calendar_items')->whereNull('state')->update(['state' => 'active']);
+
+        // Set a default at the DB level so future inserts are safe across DB engines
+        Schema::table('calendar_items', function (Blueprint $table) {
+            // Laravel doesn't support altering existing columns without doctrine/dbal.
+            // Use raw SQL below when possible.
+        });
+
+        $driver = DB::getDriverName();
+
+        if ($driver === 'pgsql') {
+            DB::statement("ALTER TABLE calendar_items ALTER COLUMN state SET DEFAULT 'active'");
+            // Keep NOT NULL as-is; if it was relaxed, enforce it.
+            DB::statement("ALTER TABLE calendar_items ALTER COLUMN state SET NOT NULL");
+        } elseif ($driver === 'mysql') {
+            // MySQL: make sure default exists; keep column NOT NULL
+            DB::statement("ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL DEFAULT 'active'");
+        } elseif ($driver === 'sqlite') {
+            // SQLite can't reliably alter column defaults without table rebuild; backfill is still valuable.
+        }
+    }
+
+    public function down()
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'pgsql') {
+            DB::statement("ALTER TABLE calendar_items ALTER COLUMN state DROP DEFAULT");
+        } elseif ($driver === 'mysql') {
+            DB::statement("ALTER TABLE calendar_items MODIFY state VARCHAR(255) NOT NULL");
+        }
+    }
+}

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -26,11 +26,216 @@ use Modules\LJPcCalendarModule\Jobs\UpdateExternalCalendarJob;
 use Modules\Teams\Providers\TeamsServiceProvider as Teams;
 
 class LJPcCalendarModuleAPIController extends Controller {
+		/**
+		 * Prefix used to namespace Team principals in permissions.
+		 *
+		 * Why: Teams and Users can share the same numeric ID space in different tables/modules.
+		 * Storing permissions keyed only by numbers can cause silent overwrites or pruning.
+		 */
+		private const TEAM_PRINCIPAL_PREFIX = 't:';
+
+		/**
+		 * Teams module compatibility: depending on FreeScout/Teams versions, getTeams()
+		 * may return Eloquent models or plain arrays. Normalize access.
+		 */
+		private function teamId( $team ): ?string {
+			if ( is_object( $team ) && isset( $team->id ) ) {
+				return (string) $team->id;
+			}
+			if ( is_array( $team ) && isset( $team['id'] ) ) {
+				return (string) $team['id'];
+			}
+			return null;
+		}
+
+		private function teamLabel( $team ): string {
+			// Teams module historically uses "getFirstName()" (Team model extends User-ish API)
+			if ( is_object( $team ) ) {
+				if ( method_exists( $team, 'getFirstName' ) ) {
+					return (string) $team->getFirstName();
+				}
+				if ( isset( $team->name ) ) {
+					return (string) $team->name;
+				}
+				if ( isset( $team->title ) ) {
+					return (string) $team->title;
+				}
+			}
+			if ( is_array( $team ) ) {
+				return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
+			}
+			return '';
+		}
+		/**
+		 * Build a map of all currently valid "principals" that can appear in calendar permissions.
+		 *
+		 * Principals are:
+		 *  - Active users (App\\User)
+		 *  - Teams (if the Teams module is installed)
+		 *
+		 * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
+		 */
+private function getValidPrincipals(): array {
+	$users = [];
+	$teams = [];
+
+	// Teams (optional module)
+	if ( class_exists( Teams::class ) ) {
+		// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
+		// Casting a Collection to array yields internal properties, not items, which would
+		// make us think there are no teams and prune all team permissions on save.
+		foreach ( Teams::getTeams( true ) as $team ) {
+			$teamId = $this->teamId( $team );
+			if ( $teamId === null ) {
+				continue;
+			}
+			$teams[$teamId] = true;
+		}
+	}
+
+	// Active users
+	$allUsers = User::where( 'status', User::STATUS_ACTIVE )
+	              ->remember( Helper::cacheTime() )
+	              ->get();
+	foreach ( $allUsers as $user ) {
+		$users[(string) $user->id] = true;
+	}
+
+	// Canonical permission keys: users are numeric strings; teams are namespaced.
+	$valid = $users;
+	foreach ( array_keys( $teams ) as $teamId ) {
+		$valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
+	}
+
+	return [
+		'users' => $users,
+		'teams' => $teams,
+		'valid' => $valid,
+	];
+}
+
+private function isTeamKey( string $key ): bool {
+	return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
+		|| str_starts_with( $key, 'team_' )
+		|| str_starts_with( $key, 'team:' );
+}
+
+private function normalizeTeamKey( string $key ): ?string {
+	if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
+		$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
+		return ctype_digit( $id ) ? $id : null;
+	}
+	if ( str_starts_with( $key, 'team_' ) ) {
+		$id = substr( $key, 5 );
+		return ctype_digit( $id ) ? $id : null;
+	}
+	if ( str_starts_with( $key, 'team:' ) ) {
+		$id = substr( $key, 5 );
+		return ctype_digit( $id ) ? $id : null;
+	}
+	return null;
+}
+
+
+		/**
+		 * Remove permission rows for principals (teams/users) that no longer exist.
+		 * This fixes stale permission keys after deleting a team (Teams module) or deactivating a user.
+		 *
+		 * @param array|null $permissions
+		 * @return array
+		 */
+		private function sanitizePermissions( $permissions ): array {
+			if ( ! is_array( $permissions ) ) {
+				return [];
+			}
+
+			$principals = $this->getValidPrincipals();
+			$valid      = $principals['valid'];
+			$clean = [];
+
+foreach ( $permissions as $id => $permission ) {
+	$key = (string) $id;
+
+	// Canonicalize team keys.
+	if ( $this->isTeamKey( $key ) ) {
+		$teamId = $this->normalizeTeamKey( $key );
+		if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
+			continue;
+		}
+		$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
+	} else if ( ctype_digit( $key ) ) {
+		// Backward compatibility: legacy numeric team IDs.
+		// Prefer users when ambiguous (user ID and team ID overlap).
+		if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
+			$key = self::TEAM_PRINCIPAL_PREFIX . $key;
+		}
+	}
+
+	if ( ! isset( $valid[$key] ) ) {
+		continue;
+	}
+
+	$clean[$key] = [
+					'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
+					'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
+					'createItems'     => (bool) ( $permission['createItems'] ?? false ),
+					'editItems'       => (bool) ( $permission['editItems'] ?? false ),
+				];
+			}
+
+			return $clean;
+		}
+
+		/**
+		 * Normalize permissions payload from the UI.
+		 *
+		 * The UI may send permissions either as:
+		 *  - an associative array keyed by principal id (preferred), or
+		 *  - a numerically indexed list of objects with an 'id' field.
+		 *
+		 * Without normalization, numeric indexes (0,1,2,...) get treated as IDs and
+		 * sanitizePermissions() prunes everything as "invalid", making changes appear not to save.
+		 *
+		 * @param mixed $raw
+		 * @return array
+		 */
+		private function normalizePermissionsInput( $raw ): array {
+			if ( ! is_array( $raw ) ) {
+				return [];
+			}
+
+			// If it already looks like an associative map keyed by IDs, keep as-is.
+			$keys = array_keys( $raw );
+			$allNumeric = true;
+			foreach ( $keys as $k ) {
+				$kStr = (string) $k;
+				if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
+					$allNumeric = false;
+					break;
+				}
+			}
+			if ( ! $allNumeric ) {
+				return $raw;
+			}
+
+			// Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
+			$map = [];
+			foreach ( $raw as $row ) {
+				if ( is_array( $row ) && ! empty( $row['id'] ) ) {
+					$map[(string) $row['id']] = $row;
+				}
+			}
+
+			return $map;
+		}
+
+
 		private function requireAuthUserId(): int {
 				$userId = auth()->id();
 				if ( ! $userId ) {
 						abort( 401, 'Unauthenticated' );
 				}
+
 				return (int) $userId;
 		}
 
@@ -58,9 +263,13 @@ class LJPcCalendarModuleAPIController extends Controller {
 				// Add team members to the response array
 				/** @var Team $team */
 				foreach ( $allTeams as $team ) {
+					$teamId = $this->teamId( $team );
+					if ( $teamId === null ) {
+						continue;
+					}
 						$response['results'][] = [
-								'id'   => (string) $team->id,
-								'text' => 'Team: ' . $team->getFirstName(),
+						'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
+						'text' => 'Team: ' . $this->teamLabel( $team ),
 						];
 				}
 
@@ -83,6 +292,15 @@ class LJPcCalendarModuleAPIController extends Controller {
 		 */
 		public function getCalendars(): JsonResponse {
 				$calendars = Calendar::all();
+
+				// Prune stale permission keys (e.g. deleted Teams principals) to avoid broken UI and errors.
+				foreach ( $calendars as $calendar ) {
+					$clean = $this->sanitizePermissions( $calendar->permissions );
+					if ( $clean !== ( $calendar->permissions ?? [] ) ) {
+						$calendar->permissions = $clean;
+						$calendar->save();
+					}
+				}
 
 				return response()->json( $calendars );
 		}
@@ -122,17 +340,17 @@ class LJPcCalendarModuleAPIController extends Controller {
 								'refresh'  => $request->input( 'refresh' ),
 						] );
 				}
-
 				$permissions = [];
-				foreach ( (array) $request->input( 'permissions', [] ) as $id => $permission ) {
+				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
+				foreach ( $rawPermissions as $id => $permission ) {
 						$permissions[ $id ] = [
-							'showInDashboard' => $permission['showInDashboard'] ?? false,
-							'showInCalendar'  => $permission['showInCalendar'] ?? false,
-							'createItems'     => $permission['createItems'] ?? false,
-							'editItems'       => $permission['editItems'] ?? false,
+								'showInDashboard' => $permission['showInDashboard'] ?? false,
+								'showInCalendar'  => $permission['showInCalendar'] ?? false,
+								'createItems'     => $permission['createItems'] ?? false,
+								'editItems'       => $permission['editItems'] ?? false,
 						];
 				}
-				$calendar->permissions = $permissions;
+				$calendar->permissions = $this->sanitizePermissions( $permissions );
 
 				$calendar->save();
 
@@ -147,17 +365,17 @@ class LJPcCalendarModuleAPIController extends Controller {
 		 * @return array The validated and sanitized custom fields
 		 */
 		private function validateCustomFields( array $customFields ): array {
-												if ( empty($customFields['fields']) || !is_array($customFields['fields']) ) {
-																return [ 'fields' => [] ];
-}
+				if ( empty( $customFields['fields'] ) || ! is_array( $customFields['fields'] ) ) {
+						return [ 'fields' => [] ];
+				}
 				$validatedFields = [];
 
 				foreach ( $customFields['fields'] as $field ) {
 						$validatedField = [
 								'id'       => $field['id'] ?? null,
-								'name' => strip_tags($field['name'] ?? ''),
+								'name'     => strip_tags( $field['name'] ?? '' ),
 								'type'     => in_array( $field['type'], [ 'text', 'number', 'dropdown', 'boolean', 'multiselect', 'date', 'email', 'source' ] ) ? $field['type'] : 'text',
-								'required' => (bool) ($field['required'] ?? false),
+								'required' => (bool) ( $field['required'] ?? false ),
 						];
 
 						if ( $validatedField['type'] === 'source' ) {
@@ -165,11 +383,11 @@ class LJPcCalendarModuleAPIController extends Controller {
 						}
 
 						if ( in_array( $field['type'], [ 'dropdown', 'multiselect' ] ) ) {
-																$options = $field['options'] ?? [];
-																if (!is_array($options)) {
-																   $options = explode(',', $options);
-																}
-										    $validatedField['options'] = array_map('trim', array_map(fn($opt) => strip_tags((string)$opt), $options));				
+								$options = $field['options'] ?? [];
+								if ( ! is_array( $options ) ) {
+										$options = explode( ',', $options );
+								}
+								$validatedField['options'] = array_map( 'trim', array_map( fn( $opt ) => strip_tags( (string) $opt ), $options ) );
 						}
 
 						$validatedFields[] = $validatedField;
@@ -188,7 +406,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 		public function addCalendar( Request $request ) {
 				$calendar = new Calendar();
 
-				$calendar->name           = strip_tags($request->input('name') ?? 'Default Calendar');
+				$calendar->name           = strip_tags( $request->input( 'name' ) ?? 'Default Calendar' );
 				$calendar->color          = $request->input( 'color' );
 				$calendar->type           = $request->input( 'type' );
 				$calendar->title_template = $request->input( 'title_template' );
@@ -209,17 +427,17 @@ class LJPcCalendarModuleAPIController extends Controller {
 								'refresh'  => $request->input( 'refresh' ),
 						];
 				}
-
 				$permissions = [];
-				foreach ( (array) $request->input( 'permissions', [] ) as $id => $permission ) {
-							$permissions[ $id ] = [
+				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
+				foreach ( $rawPermissions as $id => $permission ) {
+						$permissions[ $id ] = [
 								'showInDashboard' => $permission['showInDashboard'],
 								'showInCalendar'  => $permission['showInCalendar'],
 								'createItems'     => $permission['createItems'] ?? false,
 								'editItems'       => $permission['editItems'] ?? false,
 						];
 				}
-				$calendar->permissions = $permissions;
+				$calendar->permissions = $this->sanitizePermissions( $permissions );
 
 				$calendar->save();
 
@@ -260,7 +478,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 
 		/**
 		 * Get events
-		 * 
+		 *
 		 * This method handles both date range queries and specific event ID lookups.
 		 * For event ID lookups on external calendars, it uses an optimized approach
 		 * that avoids loading unnecessary date ranges, improving performance for large calendars.
@@ -339,7 +557,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 												try {
 														// Use the new optimized method for finding a single event
 														$event = $calendar->findEventById( $eventId );
-														
+
 														if ( $event ) {
 																// Found the event, prepare it for return
 																if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
@@ -505,7 +723,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 						$calendarItem->start    = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
 						$calendarItem->end      = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
 						$calendarItem->location = $validatedData['location'];
-						$calendarItem->body = $validatedData['body'] ?? '';
+						$calendarItem->body     = $validatedData['body'] ?? '';
 						if ( ! is_array( $calendarItem->custom_fields ) ) {
 								$calendarItem->custom_fields = [];
 						}
@@ -516,10 +734,10 @@ class LJPcCalendarModuleAPIController extends Controller {
 						$fullUrl = $calendar->custom_fields['url'] ?? '';
 
 						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-							return response()->json( [
-								'status'  => 'error',
-								'message' => 'CalDAV calendar is not properly configured (missing URL).',
-							], 422 );
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
 						}
 
 						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
@@ -618,10 +836,10 @@ class LJPcCalendarModuleAPIController extends Controller {
 						$fullUrl = $calendar->custom_fields['url'] ?? '';
 
 						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-							return response()->json( [
-								'status'  => 'error',
-								'message' => 'CalDAV calendar is not properly configured (missing URL).',
-							], 422 );
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
 						}
 
 						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
@@ -717,30 +935,33 @@ class LJPcCalendarModuleAPIController extends Controller {
 				$isAllDay = DateTimeRange::isAllDay( $start, $end );
 
 				if ( $calendar->type === 'normal' ) {
-$calendarItem = new CalendarItem();
+						$calendarItem = new CalendarItem();
 
-$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-$calendarItem->author_id   = $userId;
-$calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
-$calendarItem->start       = $start ?? Carbon::now();
-$calendarItem->end         = $end ?? Carbon::now()->addHour();
-$calendarItem->is_all_day  = $isAllDay ?? false;
-$calendarItem->is_private  = $validatedData['is_private'] ?? false;
-$calendarItem->state       = $validatedData['state'] ?? 'active';
+						$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+						$calendarItem->author_id   = $userId;
+						$calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
+						$calendarItem->start       = $start ?? Carbon::now();
+						$calendarItem->end         = $end ?? Carbon::now()->addHour();
+						$calendarItem->is_all_day  = $isAllDay ?? false;
+									$calendarItem->is_private  = false;
+									$calendarItem->is_read_only = false;
+									$calendarItem->state       = 'active';
+						$calendarItem->is_private  = $validatedData['is_private'] ?? false;
+						$calendarItem->state       = $validatedData['state'] ?? 'active';
 
-$calendarItem->location      = $validatedData['location'] ?? '';
-$calendarItem->body          = $validatedData['body'] ?? '';
-$calendarItem->custom_fields = $processedCustomFields ?? [];
+						$calendarItem->location      = $validatedData['location'] ?? '';
+						$calendarItem->body          = $validatedData['body'] ?? '';
+						$calendarItem->custom_fields = $processedCustomFields ?? [];
 
-$calendarItem->save();
+						$calendarItem->save();
 				} else if ( $calendar->type === 'caldav' ) {
 						$fullUrl = $calendar->custom_fields['url'] ?? '';
 
 						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-							return response()->json( [
-								'status'  => 'error',
-								'message' => 'CalDAV calendar is not properly configured (missing URL).',
-							], 422 );
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
 						}
 
 						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
@@ -785,40 +1006,40 @@ $calendarItem->save();
 		}
 
 		private function processTemplate(
-	string $template,
-	?Conversation $conversation,
-	Calendar $calendar,
-	array $customFields = []
-): string {
-	if (!$conversation) {
-		return $template;
-	}
+				string        $template,
+				?Conversation $conversation,
+				Calendar      $calendar,
+				array         $customFields = []
+		): string {
+				if ( ! $conversation ) {
+						return $template;
+				}
 
-	$result = str_replace('{{title}}', $conversation->subject, $template);
+				$result = str_replace( '{{title}}', $conversation->subject, $template );
 
-	// Get the field name mapping from calendar's custom fields configuration
-	$fieldMapping = [];
+				// Get the field name mapping from calendar's custom fields configuration
+				$fieldMapping = [];
 
-	if (!empty($calendar->custom_fields['fields'])) {
-		foreach ($calendar->custom_fields['fields'] as $field) {
-			$fieldMapping['custom_field_' . $field['id']] = $field['name'];
+				if ( ! empty( $calendar->custom_fields['fields'] ) ) {
+						foreach ( $calendar->custom_fields['fields'] as $field ) {
+								$fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
+						}
+				}
+
+				// Process custom fields using the mapping
+				foreach ( $customFields as $fieldId => $value ) {
+						if ( is_array( $value ) ) {
+								$value = implode( ', ', $value );
+						}
+
+						if ( isset( $fieldMapping[ $fieldId ] ) ) {
+								$fieldName = $fieldMapping[ $fieldId ];
+								$result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
+						}
+				}
+
+				return $result;
 		}
-	}
-
-	// Process custom fields using the mapping
-	foreach ($customFields as $fieldId => $value) {
-		if (is_array($value)) {
-			$value = implode(', ', $value);
-		}
-
-		if (isset($fieldMapping[$fieldId])) {
-			$fieldName = $fieldMapping[$fieldId];
-			$result = str_replace('{{' . $fieldName . '}}', $value ?? '', $result);
-		}
-	}
-
-	return $result;
-}
 
 
 		/**
@@ -851,7 +1072,7 @@ $calendarItem->save();
 				}
 
 				$userId = $this->requireAuthUserId();
-				
+
 				$conversationObj = Conversation::find( $conversation );
 
 				$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
@@ -882,49 +1103,52 @@ $calendarItem->save();
 				if ( $calendar->type === 'normal' ) {
 						$calendarItem = new CalendarItem();
 
-								$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-								$calendarItem->author_id   = $userId;
-								$calendarItem->title       = $this->processTemplate(
+						$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+						$calendarItem->author_id   = $userId;
+						$calendarItem->title       = $this->processTemplate(
 								$calendar->title_template,
 								$conversationObj,
 								$calendar,
 								$processedCustomFields ?? []
-								);
-								$calendarItem->start      = $start ?? Carbon::now();
-								$calendarItem->end        = $end ?? Carbon::now()->addHour();
-								$calendarItem->is_all_day = $isAllDay ?? false;
-								$calendarItem->is_private = false;
-								$calendarItem->state      = 'active';
-								$calendarItem->location   = $validatedData['location'] ?? '';
-								$calendarItem->body       = $validatedData['body'] ?? '';
+						);
+						$calendarItem->start       = $start ?? Carbon::now();
+						$calendarItem->end         = $end ?? Carbon::now()->addHour();
+						$calendarItem->is_all_day  = $isAllDay ?? false;
+									$calendarItem->is_private  = false;
+									$calendarItem->is_read_only = false;
+									$calendarItem->state       = 'active';
+						$calendarItem->is_private  = false;
+						$calendarItem->state       = 'active';
+						$calendarItem->location    = $validatedData['location'] ?? '';
+						$calendarItem->body        = $validatedData['body'] ?? '';
 
-								// Merge all custom fields safely
-								$customFields = $calendarItem->custom_fields;
-								if (!is_array($customFields)) {
+						// Merge all custom fields safely
+						$customFields = $calendarItem->custom_fields;
+						if ( ! is_array( $customFields ) ) {
 								$customFields = [];
-								}
+						}
 
-								$mergedCustomFields = array_merge(
+						$mergedCustomFields = array_merge(
 								$customFields,
 								[
-								'conversation_id' => $conversation,
-								'author_id'       => $userId,
+										'conversation_id' => $conversation,
+										'author_id'       => $userId,
 								],
 								$processedCustomFields ?? []
-								);
+						);
 
-								$calendarItem->custom_fields = $mergedCustomFields;
+						$calendarItem->custom_fields = $mergedCustomFields;
 
-								$calendarItem->save();
+						$calendarItem->save();
 						$uid = $calendarItem->id;
 				} else if ( $calendar->type === 'caldav' ) {
 						$fullUrl = $calendar->custom_fields['url'] ?? '';
 
 						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-							return response()->json( [
-								'status'  => 'error',
-								'message' => 'CalDAV calendar is not properly configured (missing URL).',
-							], 422 );
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
 						}
 
 						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
@@ -976,7 +1200,7 @@ $calendarItem->save();
 						if ( $conversation !== null ) {
 								$action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
 								$created_by_user_id = $userId;
-								
+
 								// Store the event UID for better permalink support
 								$meta = [
 										'calendar_item_id' => $uid,
@@ -984,12 +1208,12 @@ $calendarItem->save();
 										'calendar_type'    => $calendar->type,
 										'start'            => ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) )->format( DATE_ATOM ),
 								];
-								
+
 								// For external calendars, also store the event UID
 								if ( $calendar->type === 'caldav' || $calendar->type === 'ics' ) {
 										$meta['event_uid'] = $uid;
 								}
-								
+
 								Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
 										'user_id'            => $conversation->user_id,
 										'created_by_user_id' => $created_by_user_id,
@@ -1017,6 +1241,13 @@ $calendarItem->save();
 						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
 				}
 
+				// Ensure we never return stale principals to the settings UI
+				$clean = $this->sanitizePermissions( $calendar->permissions );
+				if ( $clean !== ( $calendar->permissions ?? [] ) ) {
+					$calendar->permissions = $clean;
+					$calendar->save();
+				}
+
 				return response()->json( $calendar );
 		}
 
@@ -1035,12 +1266,12 @@ $calendarItem->save();
 						}
 
 						$calendars = Calendar::all();
-						
+
 						foreach ( $calendars as $calendar ) {
 								if ( $calendar->enabled === false ) {
 										continue;
 								}
-								
+
 								$permissions = $calendar->permissionsForCurrentUser();
 								if ( $permissions === null || ! $permissions['showInCalendar'] ) {
 										continue;
@@ -1054,7 +1285,7 @@ $calendarItem->save();
 
 										if ( $event ) {
 												$eventData = json_decode( $event->toJson(), true );
-												
+
 												// Ensure calendar ID is present
 												$eventData['calendarId'] = $calendar->id;
 
@@ -1092,12 +1323,12 @@ $calendarItem->save();
 								if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
 										try {
 												$event = $calendar->findEventById( $eventId );
-												
+
 												if ( $event ) {
 														// Add calendar ID to the event data
-														$event['calendarId'] = $calendar->id;
+														$event['calendarId']  = $calendar->id;
 														$event['calendar_id'] = $calendar->id;
-														
+
 														// Generate mapping for used custom fields
 														if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
 																$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
@@ -1105,14 +1336,14 @@ $calendarItem->save();
 																		$event['custom_fields']
 																);
 														}
-														
+
 														// Ensure timezone conversion is done
 														$defaultTimezone = config( 'app.timezone' );
-														$event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )
+														$event['start']  = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )
 																->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-														$event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )
+														$event['end']    = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )
 																->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-														
+
 														return response()->json( $event );
 												}
 										} catch ( \Exception $e ) {
@@ -1124,9 +1355,10 @@ $calendarItem->save();
 
 						// Event not found in any calendar
 						return response()->json( [ 'error' => 'Event not found' ], 404 );
-						
+
 				} catch ( \Exception $e ) {
 						\Log::error( 'Error in getEventById: ' . $e->getMessage() );
+
 						return response()->json( [ 'error' => 'Failed to retrieve event' ], 500 );
 				}
 		}
@@ -1196,27 +1428,30 @@ $calendarItem->save();
 						if ( $calendar->type === 'normal' ) {
 								$calendarItem = new CalendarItem();
 
-												$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-												$calendarItem->author_id   = $userId;
-												$calendarItem->title       = $event->summary ?? 'Untitled Event';
-												$calendarItem->start       = $start ?? Carbon::now();
-												$calendarItem->end         = $end ?? Carbon::now()->addHour();
-												$calendarItem->is_all_day  = $isAllDay ?? false;
-												$calendarItem->location    = $event->location ?? '';
-												$calendarItem->body        = $event->description ?? '';
+								$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+								$calendarItem->author_id   = $userId;
+								$calendarItem->title       = $event->summary ?? 'Untitled Event';
+								$calendarItem->start       = $start ?? Carbon::now();
+								$calendarItem->end         = $end ?? Carbon::now()->addHour();
+								$calendarItem->is_all_day  = $isAllDay ?? false;
+									$calendarItem->is_private  = false;
+									$calendarItem->is_read_only = false;
+									$calendarItem->state       = 'active';
+								$calendarItem->location    = $event->location ?? '';
+								$calendarItem->body        = $event->description ?? '';
 
-												 // Merge custom fields safely
-												$customFields = $calendarItem->custom_fields;
-												if (!is_array($customFields)) {
-												$customFields = [];
-												}
+								// Merge custom fields safely
+								$customFields = $calendarItem->custom_fields;
+								if ( ! is_array( $customFields ) ) {
+										$customFields = [];
+								}
 
-												$customFields['conversation_id'] = $conversation ? $conversation->id : null;
-												$customFields['author_id']       = $userId;
+								$customFields['conversation_id'] = $conversation ? $conversation->id : null;
+								$customFields['author_id']       = $userId;
 
-												$calendarItem->custom_fields = $customFields;
+								$calendarItem->custom_fields = $customFields;
 
-												$calendarItem->save();
+								$calendarItem->save();
 								$uid = $calendarItem->id;
 						} else if ( $calendar->type === 'caldav' ) {
 								$fullUrl      = $calendar->custom_fields['url'];

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -26,1507 +26,1506 @@ use Modules\LJPcCalendarModule\Jobs\UpdateExternalCalendarJob;
 use Modules\Teams\Providers\TeamsServiceProvider as Teams;
 
 class LJPcCalendarModuleAPIController extends Controller {
-		/**
-		 * Prefix used to namespace Team principals in permissions.
-		 *
-		 * Why: Teams and Users can share the same numeric ID space in different tables/modules.
-		 * Storing permissions keyed only by numbers can cause silent overwrites or pruning.
-		 */
-		private const TEAM_PRINCIPAL_PREFIX = 't:';
-
-		/**
-		 * Teams module compatibility: depending on FreeScout/Teams versions, getTeams()
-		 * may return Eloquent models or plain arrays. Normalize access.
-		 */
-		private function teamId( $team ): ?string {
-			if ( is_object( $team ) && isset( $team->id ) ) {
-				return (string) $team->id;
-			}
-			if ( is_array( $team ) && isset( $team['id'] ) ) {
-				return (string) $team['id'];
-			}
-			return null;
-		}
-
-		private function teamLabel( $team ): string {
-			// Teams module historically uses "getFirstName()" (Team model extends User-ish API)
-			if ( is_object( $team ) ) {
-				if ( method_exists( $team, 'getFirstName' ) ) {
-					return (string) $team->getFirstName();
-				}
-				if ( isset( $team->name ) ) {
-					return (string) $team->name;
-				}
-				if ( isset( $team->title ) ) {
-					return (string) $team->title;
-				}
-			}
-			if ( is_array( $team ) ) {
-				return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
-			}
-			return '';
-		}
-		/**
-		 * Build a map of all currently valid "principals" that can appear in calendar permissions.
-		 *
-		 * Principals are:
-		 *  - Active users (App\\User)
-		 *  - Teams (if the Teams module is installed)
-		 *
-		 * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
-		 */
-private function getValidPrincipals(): array {
-	$users = [];
-	$teams = [];
-
-	// Teams (optional module)
-	if ( class_exists( Teams::class ) ) {
-		// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
-		// Casting a Collection to array yields internal properties, not items, which would
-		// make us think there are no teams and prune all team permissions on save.
-		foreach ( Teams::getTeams( true ) as $team ) {
-			$teamId = $this->teamId( $team );
-			if ( $teamId === null ) {
-				continue;
-			}
-			$teams[$teamId] = true;
-		}
-	}
-
-	// Active users
-	$allUsers = User::where( 'status', User::STATUS_ACTIVE )
-	              ->remember( Helper::cacheTime() )
-	              ->get();
-	foreach ( $allUsers as $user ) {
-		$users[(string) $user->id] = true;
-	}
-
-	// Canonical permission keys: users are numeric strings; teams are namespaced.
-	$valid = $users;
-	foreach ( array_keys( $teams ) as $teamId ) {
-		$valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
-	}
-
-	return [
-		'users' => $users,
-		'teams' => $teams,
-		'valid' => $valid,
-	];
-}
-
-private function isTeamKey( string $key ): bool {
-	return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
-		|| str_starts_with( $key, 'team_' )
-		|| str_starts_with( $key, 'team:' );
-}
-
-private function normalizeTeamKey( string $key ): ?string {
-	if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
-		$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	if ( str_starts_with( $key, 'team_' ) ) {
-		$id = substr( $key, 5 );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	if ( str_starts_with( $key, 'team:' ) ) {
-		$id = substr( $key, 5 );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	return null;
-}
-
-
-		/**
-		 * Remove permission rows for principals (teams/users) that no longer exist.
-		 * This fixes stale permission keys after deleting a team (Teams module) or deactivating a user.
-		 *
-		 * @param array|null $permissions
-		 * @return array
-		 */
-		private function sanitizePermissions( $permissions ): array {
-			if ( ! is_array( $permissions ) ) {
-				return [];
-			}
-
-			$principals = $this->getValidPrincipals();
-			$valid      = $principals['valid'];
-			$clean = [];
-
-foreach ( $permissions as $id => $permission ) {
-	$key = (string) $id;
-
-	// Canonicalize team keys.
-	if ( $this->isTeamKey( $key ) ) {
-		$teamId = $this->normalizeTeamKey( $key );
-		if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
-			continue;
-		}
-		$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
-	} else if ( ctype_digit( $key ) ) {
-		// Backward compatibility: legacy numeric team IDs.
-		// Prefer users when ambiguous (user ID and team ID overlap).
-		if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
-			$key = self::TEAM_PRINCIPAL_PREFIX . $key;
-		}
-	}
-
-	if ( ! isset( $valid[$key] ) ) {
-		continue;
-	}
-
-	$clean[$key] = [
-					'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
-					'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
-					'createItems'     => (bool) ( $permission['createItems'] ?? false ),
-					'editItems'       => (bool) ( $permission['editItems'] ?? false ),
-				];
-			}
-
-			return $clean;
-		}
-
-		/**
-		 * Normalize permissions payload from the UI.
-		 *
-		 * The UI may send permissions either as:
-		 *  - an associative array keyed by principal id (preferred), or
-		 *  - a numerically indexed list of objects with an 'id' field.
-		 *
-		 * Without normalization, numeric indexes (0,1,2,...) get treated as IDs and
-		 * sanitizePermissions() prunes everything as "invalid", making changes appear not to save.
-		 *
-		 * @param mixed $raw
-		 * @return array
-		 */
-		private function normalizePermissionsInput( $raw ): array {
-			if ( ! is_array( $raw ) ) {
-				return [];
-			}
-
-			// If it already looks like an associative map keyed by IDs, keep as-is.
-			$keys = array_keys( $raw );
-			$allNumeric = true;
-			foreach ( $keys as $k ) {
-				$kStr = (string) $k;
-				if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
-					$allNumeric = false;
-					break;
-				}
-			}
-			if ( ! $allNumeric ) {
-				return $raw;
-			}
-
-			// Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
-			$map = [];
-			foreach ( $raw as $row ) {
-				if ( is_array( $row ) && ! empty( $row['id'] ) ) {
-					$map[(string) $row['id']] = $row;
-				}
-			}
-
-			return $map;
-		}
-
-
-		private function requireAuthUserId(): int {
-				$userId = auth()->id();
-				if ( ! $userId ) {
-						abort( 401, 'Unauthenticated' );
-				}
-
-				return (int) $userId;
-		}
-
-		/**
-		 * Get users for the settings
-		 *
-		 * @return JsonResponse A JSON response containing an array of user objects
-		 */
-		public function getUsers(): JsonResponse {
-				$response = [
-						'results' => [],
-				];
-
-				// Get all teams
-				$allTeams = [];
-				if ( class_exists( Teams::class ) ) {
-						$allTeams = Teams::getTeams( true );
-				}
-
-				// Get all users that are active
-				$allUsers = User::where( 'status', User::STATUS_ACTIVE )
-				                ->remember( Helper::cacheTime() )
-				                ->get();
-
-				// Add team members to the response array
-				/** @var Team $team */
-				foreach ( $allTeams as $team ) {
-					$teamId = $this->teamId( $team );
-					if ( $teamId === null ) {
-						continue;
-					}
-						$response['results'][] = [
-						'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
-						'text' => 'Team: ' . $this->teamLabel( $team ),
-						];
-				}
-
-				// Add users to the response array
-				/** @var User $user */
-				foreach ( $allUsers as $user ) {
-						$response['results'][] = [
-								'id'   => (string) $user->id,
-								'text' => $user->getFullName(),
-						];
-				}
-
-				return response()->json( $response );
-		}
-
-		/**
-		 * Get calendars for the settings
-		 *
-		 * @return JsonResponse A JSON response containing an array of calendar objects
-		 */
-		public function getCalendars(): JsonResponse {
-				$calendars = Calendar::all();
-
-				// Prune stale permission keys (e.g. deleted Teams principals) to avoid broken UI and errors.
-				foreach ( $calendars as $calendar ) {
-					$clean = $this->sanitizePermissions( $calendar->permissions );
-					if ( $clean !== ( $calendar->permissions ?? [] ) ) {
-						$calendar->permissions = $clean;
-						$calendar->save();
-					}
-				}
-
-				return response()->json( $calendars );
-		}
-
-		/**
-		 * Update a calendar
-		 *
-		 * @param int $id The ID of the calendar to update
-		 * @param Request $request The request object
-		 *
-		 * @return JsonResponse A JSON response containing the updated calendar object
-		 */
-		public function updateCalendar( int $id, Request $request ) {
-				$calendar = Calendar::find( $id );
-
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				$calendar->name           = $request->input( 'name' );
-				$calendar->color          = $request->input( 'color' );
-				$calendar->title_template = $request->input( 'title_template' );
-
-				$customFields            = $request->input( 'custom_fields', [] );
-				$calendar->custom_fields = $this->validateCustomFields( $customFields );
-
-				if ( $calendar->type === 'ics' ) {
-						$calendar->custom_fields = array_merge( $calendar->custom_fields, [
-								'url'     => $request->input( 'url' ),
-								'refresh' => $request->input( 'refresh' ),
-						] );
-				} else if ( $calendar->type === 'caldav' ) {
-						$calendar->custom_fields = array_merge( $calendar->custom_fields, [
-								'url'      => $request->input( 'url' ),
-								'username' => $request->input( 'username' ),
-								'password' => $request->input( 'password' ),
-								'refresh'  => $request->input( 'refresh' ),
-						] );
-				}
-				$permissions = [];
-				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
-				foreach ( $rawPermissions as $id => $permission ) {
-						$permissions[ $id ] = [
-								'showInDashboard' => $permission['showInDashboard'] ?? false,
-								'showInCalendar'  => $permission['showInCalendar'] ?? false,
-								'createItems'     => $permission['createItems'] ?? false,
-								'editItems'       => $permission['editItems'] ?? false,
-						];
-				}
-				$calendar->permissions = $this->sanitizePermissions( $permissions );
-
-				$calendar->save();
-
-				return response()->json( $calendar );
-		}
-
-		/**
-		 * Validate and sanitize custom fields
-		 *
-		 * @param array $customFields The custom fields to validate
-		 *
-		 * @return array The validated and sanitized custom fields
-		 */
-		private function validateCustomFields( array $customFields ): array {
-				if ( empty( $customFields['fields'] ) || ! is_array( $customFields['fields'] ) ) {
-						return [ 'fields' => [] ];
-				}
-				$validatedFields = [];
-
-				foreach ( $customFields['fields'] as $field ) {
-						$validatedField = [
-								'id'       => $field['id'] ?? null,
-								'name'     => strip_tags( $field['name'] ?? '' ),
-								'type'     => in_array( $field['type'], [ 'text', 'number', 'dropdown', 'boolean', 'multiselect', 'date', 'email', 'source' ] ) ? $field['type'] : 'text',
-								'required' => (bool) ( $field['required'] ?? false ),
-						];
-
-						if ( $validatedField['type'] === 'source' ) {
-								$validatedField['required'] = false;
-						}
-
-						if ( in_array( $field['type'], [ 'dropdown', 'multiselect' ] ) ) {
-								$options = $field['options'] ?? [];
-								if ( ! is_array( $options ) ) {
-										$options = explode( ',', $options );
-								}
-								$validatedField['options'] = array_map( 'trim', array_map( fn( $opt ) => strip_tags( (string) $opt ), $options ) );
-						}
-
-						$validatedFields[] = $validatedField;
-				}
-
-				return [ 'fields' => $validatedFields ];
-		}
-
-		/**
-		 * Create a new calendar
-		 *
-		 * @param Request $request The request object
-		 *
-		 * @return JsonResponse A JSON response containing the created calendar object
-		 */
-		public function addCalendar( Request $request ) {
-				$calendar = new Calendar();
-
-				$calendar->name           = strip_tags( $request->input( 'name' ) ?? 'Default Calendar' );
-				$calendar->color          = $request->input( 'color' );
-				$calendar->type           = $request->input( 'type' );
-				$calendar->title_template = $request->input( 'title_template' );
-
-				$customFields            = $request->input( 'custom_fields', [] );
-				$calendar->custom_fields = $this->validateCustomFields( $customFields );
-
-				if ( $calendar->type === 'ics' ) {
-						$calendar->custom_fields = [
-								'url'     => $request->input( 'url' ),
-								'refresh' => $request->input( 'refresh' ),
-						];
-				} else if ( $calendar->type === 'caldav' ) {
-						$calendar->custom_fields = [
-								'url'      => $request->input( 'url' ),
-								'username' => $request->input( 'username' ),
-								'password' => $request->input( 'password' ),
-								'refresh'  => $request->input( 'refresh' ),
-						];
-				}
-				$permissions = [];
-				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
-				foreach ( $rawPermissions as $id => $permission ) {
-						$permissions[ $id ] = [
-								'showInDashboard' => $permission['showInDashboard'],
-								'showInCalendar'  => $permission['showInCalendar'],
-								'createItems'     => $permission['createItems'] ?? false,
-								'editItems'       => $permission['editItems'] ?? false,
-						];
-				}
-				$calendar->permissions = $this->sanitizePermissions( $permissions );
-
-				$calendar->save();
-
-				return response()->json( $calendar );
-		}
-
-		/**
-		 * Delete a calendar
-		 *
-		 * @param int $id The ID of the calendar to delete
-		 *
-		 * @return JsonResponse A JSON response indicating the deletion result
-		 * @throws Exception
-		 */
-		public function deleteCalendar( int $id ): JsonResponse {
-				$calendar = Calendar::find( $id );
-
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
-						//remove temporary ics file
-						$filename = $calendar->getTemporaryFile();
-						if ( file_exists( $filename ) ) {
-								unlink( $filename );
-						}
-				} else {
-						//remove all calendar items for this calendar
-						CalendarItem::where( 'calendar_id', $calendar->id )->delete();
-				}
-
-				$calendar->delete();
-
-				return response()->json( [ 'ok' => true, 'message' => 'Calendar deleted successfully' ] );
-		}
-
-
-		/**
-		 * Get events
-		 *
-		 * This method handles both date range queries and specific event ID lookups.
-		 * For event ID lookups on external calendars, it uses an optimized approach
-		 * that avoids loading unnecessary date ranges, improving performance for large calendars.
-		 *
-		 * @param Request $request The request containing either date range (start/end) or eventId
-		 *
-		 * @return JsonResponse Array of events matching the criteria
-		 * @throws Exception
-		 */
-		public function getEvents( Request $request ) {
-				// Special case: If looking for a specific event by ID
-				$eventId = $request->input( 'eventId' );
-				if ( $eventId ) {
-						try {
-								// Check if tables exist first
-								if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
-										return response()->json( [] );
-								}
-
-								$events    = [];
-								$calendars = Calendar::all();
-
-								foreach ( $calendars as $calendar ) {
-										if ( $calendar->enabled === false ) {
-												continue;
-										}
-										$permissions = $calendar->permissionsForCurrentUser();
-										if ( $permissions === null ) {
-												continue;
-										}
-										if ( $permissions['showInCalendar'] !== true ) {
-												continue;
-										}
-
-										// For normal calendars, try to find the specific event
-										if ( $calendar->type === 'normal' ) {
-												$event = CalendarItem::where( 'uid', $eventId )
-												                     ->orWhere( 'id', $eventId )
-												                     ->where( 'calendar_id', $calendar->id )
-												                     ->first();
-
-												if ( $event ) {
-														// Found the event, return it
-														$eventData = json_decode( $event->toJson(), true );
-
-														// Generate mapping for used custom fields
-														if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
-																$eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-																		$calendar->custom_fields,
-																		$eventData['custom_fields']
-																);
-														}
-
-														// Set default timezone
-														$defaultTimezone    = config( 'app.timezone' );
-														$eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-														$eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-
-														if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
-																$eventData['id'] = $eventData['uid'];
-														}
-														if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
-																$eventData['uid'] = $eventData['id'];
-														}
-														if ( empty( $eventData['title'] ) ) {
-																$eventData['title'] = '';
-														}
-
-														$events[] = $eventData;
-														break;
-												}
-										}
-
-										// For external calendars, use optimized single event lookup
-										if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
-												try {
-														// Use the new optimized method for finding a single event
-														$event = $calendar->findEventById( $eventId );
-
-														if ( $event ) {
-																// Found the event, prepare it for return
-																if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
-																		$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-																				$calendar->custom_fields,
-																				$event['custom_fields']
-																		);
-																}
-																$events[] = $event;
-																break;
-														}
-												} catch ( \Exception $e ) {
-														// Log and continue - we don't want a single calendar to break the entire request
-														\Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
-												}
-										}
-								}
-
-								// Restore timezones
-								$defaultTimezone = config( 'app.timezone' );
-								foreach ( $events as &$event ) {
-										$event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-										$event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-								}
-								unset( $event );
-
-								return response()->json( $events );
-						} catch ( \Exception $e ) {
-								// Log the error but return a valid response
-								\Log::error( 'Error in getEvents by ID: ' . $e->getMessage() );
-
-								return response()->json( [] );
-						}
-				}
-
-				try {
-						// Regular date range query
-						$request->validate( [
-								'start' => 'required|date',
-								'end'   => 'required|date',
-						] );
-
-						// Check if tables exist first
-						if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
-								return response()->json( [] );
-						}
-
-						$defaultTimezone = config( 'app.timezone' );
-
-						$start = ( new DateTimeImmutable( $request->input( 'start' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-						$end   = ( new DateTimeImmutable( $request->input( 'end' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-
-						$calendars = Calendar::all();
-						$events    = [];
-
-						foreach ( $calendars as $calendar ) {
-								if ( $calendar->enabled === false ) {
-										continue;
-								}
-								$permissions = $calendar->permissionsForCurrentUser();
-								if ( $permissions === null ) {
-										continue;
-								}
-								if ( $permissions['showInCalendar'] !== true ) {
-										continue;
-								}
-
-								try {
-										$calendarEvents = $calendar->events( $start, $end );
-										foreach ( $calendarEvents as $event ) {
-												// Generate mapping for used custom fields
-												if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
-														$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-																$calendar->custom_fields,
-																$event['custom_fields']
-														);
-												}
-												$events[] = $event;
-										}
-								} catch ( \Exception $e ) {
-										// Log and continue - we don't want a single calendar to break the entire request
-										\Log::error( 'Error fetching events from calendar ' . $calendar->id . ': ' . $e->getMessage() );
-								}
-						}
-
-						/**
-						 * Restore timezones
-						 */
-						foreach ( $events as &$event ) {
-								if ( empty( $event['id'] ) && ! empty( $event['uid'] ) ) {
-										$event['id'] = $event['uid'];
-								}
-								if ( empty( $event['uid'] ) && ! empty( $event['id'] ) ) {
-										$event['uid'] = $event['id'];
-								}
-								if ( empty( $event['title'] ) ) {
-										$event['title'] = '';
-								}
-
-								$event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-								$event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-						}
-						unset( $event );
-
-						return response()->json( $events );
-				} catch ( \Exception $e ) {
-						// Log the error but return a valid response
-						\Log::error( 'Error in getEvents date range: ' . $e->getMessage() );
-
-						return response()->json( [] );
-				}
-		}
-
-		/**
-		 * Update an event
-		 *
-		 * @param Request $request
-		 *
-		 * @return JsonResponse
-		 * @throws Exception
-		 */
-		public function updateEvent( Request $request ) {
-				try {
-						$validatedData = $request->validate( [
-								'uid'          => 'required',
-								'title'        => 'required',
-								'start'        => 'required|date',
-								'end'          => 'required|date|after:start',
-								'location'     => 'nullable',
-								'body'         => 'nullable',
-								'calendarId'   => 'required',
-								'customFields' => 'nullable',
-						] );
-				} catch ( Exception $e ) {
-						return response()->json( [ 'error' => $e->getMessage() ], 400 );
-				}
-
-				$calendar = Calendar::find( $validatedData['calendarId'] );
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				$customFieldsData      = $validatedData['customFields'] ?? [];
-				$customFields          = $calendar->custom_fields['fields'] ?? [];
-				$processedCustomFields = [];
-
-				foreach ( $customFields as $field ) {
-						$fieldId = 'custom_field_' . $field['id'];
-						if ( isset( $customFieldsData[ $fieldId ] ) ) {
-								$processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
-						} else if ( $field['required'] ) {
-								return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
-						}
-				}
-
-				if ( $calendar->type === 'normal' ) {
-						$calendarItem = CalendarItem::where( 'id', $validatedData['uid'] )->first();
-						if ( ! $calendarItem ) {
-								return response()->json( [ 'error' => 'Event not found' ], 404 );
-						}
-
-						$calendarItem->title    = $validatedData['title'];
-						$calendarItem->start    = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-						$calendarItem->end      = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-						$calendarItem->location = $validatedData['location'];
-						$calendarItem->body     = $validatedData['body'] ?? '';
-						if ( ! is_array( $calendarItem->custom_fields ) ) {
-								$calendarItem->custom_fields = [];
-						}
-						$calendarItem->custom_fields = array_merge( $calendarItem->custom_fields, $processedCustomFields );
-
-						$calendarItem->save();
-				} else if ( $calendar->type === 'caldav' ) {
-						$fullUrl = $calendar->custom_fields['url'] ?? '';
-
-						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-								return response()->json( [
-										'status'  => 'error',
-										'message' => 'CalDAV calendar is not properly configured (missing URL).',
-								], 422 );
-						}
-
-						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-						$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-						$end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-
-						if ( isset( $customFieldsData['author_id'] ) ) {
-								$processedCustomFields['author_id'] = $customFieldsData['author_id'];
-						}
-						if ( isset( $customFieldsData['conversation_id'] ) ) {
-								$processedCustomFields['conversation_id'] = $customFieldsData['conversation_id'];
-						}
-
-						if ( count( $processedCustomFields ) > 0 ) {
-								if ( ! is_array( $validatedData['body'] ) ) {
-										$validatedData['body'] = [ 'body' => $validatedData['body'] ];
-								}
-
-								if ( ! isset( $validatedData['body']['custom_fields'] ) || ! is_array( $validatedData['body']['custom_fields'] ) ) {
-										$validatedData['body']['custom_fields'] = [];
-								}
-
-								$validatedData['body']['custom_fields'] = array_merge(
-										$validatedData['body']['custom_fields'],
-										$processedCustomFields
-								);
-
-								// Add mapping for used custom fields
-								$validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-										$calendar->custom_fields,
-										$processedCustomFields
-								);
-						}
-
-						$response = $caldavClient->updateEvent(
-								$remainingUrl,
-								$validatedData['uid'],
-								$validatedData['title'],
-								$validatedData['body'],
-								$start,
-								$end,
-								$validatedData['location']
-						);
-
-						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-								Log::error( 'Error updating event', $response );
-
-								return response()->json( [ 'error' => 'Error updating event' ], 500 );
-						}
-
-						$calendar->getExternalContent( true );
-				}
-
-				return response()->json( [ 'ok' => true, 'message' => 'Event updated successfully' ] );
-		}
-
-		/**
-		 * Generate a GUID
-		 * @return string
-		 */
-		private function GUID() {
-				if ( function_exists( 'com_create_guid' ) === true ) {
-						return trim( com_create_guid(), '{}' );
-				}
-
-				return sprintf( '%04X%04X-%04X-%04X-%04X-%04X%04X%04X', mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 16384, 20479 ), mt_rand( 32768, 49151 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ) );
-		}
-
-		/**
-		 * Delete an event
-		 *
-		 * @param Request $request
-		 *
-		 * @return JsonResponse
-		 * @throws Exception
-		 */
-		public function deleteEvent( Request $request ) {
-				$eventId    = $request->input( 'id' );
-				$calendarId = $request->input( 'calendarId' );
-
-				$calendar = Calendar::find( $calendarId );
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				if ( $calendar->type === 'normal' ) {
-						$calendarItem = CalendarItem::where( 'id', $eventId )->first();
-						if ( ! $calendarItem ) {
-								return response()->json( [ 'error' => 'Event not found' ], 404 );
-						}
-						$calendarItem->delete();
-				} else if ( $calendar->type === 'caldav' ) {
-						$fullUrl = $calendar->custom_fields['url'] ?? '';
-
-						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-								return response()->json( [
-										'status'  => 'error',
-										'message' => 'CalDAV calendar is not properly configured (missing URL).',
-								], 422 );
-						}
-
-						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-						$response = $caldavClient->deleteEvent( $remainingUrl, $eventId );
-						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-								Log::error( 'Error deleting event', $response );
-
-								return response()->json( [ 'error' => 'Error deleting event' ], 500 );
-						}
-						$calendar->getExternalContent( true );
-				}
-
-				return response()->json( [ 'ok' => true, 'message' => 'Event deleted successfully' ] );
-		}
-
-		/**
-		 * Helper function to generate custom field mapping
-		 *
-		 * @param array $customFields Array of all possible custom fields
-		 * @param array $usedCustomFields Array of used custom field values
-		 *
-		 * @return array Mapping of used custom field IDs to their names
-		 */
-		private function generateCustomFieldMapping( array $customFields, array $usedCustomFields ): array {
-				$mapping = [];
-				$fields  = $customFields['fields'] ?? [];
-
-				foreach ( $fields as $field ) {
-						$fieldId = 'custom_field_' . $field['id'];
-						// Only include fields that are actually used in the item
-						if ( isset( $usedCustomFields[ $fieldId ] ) ) {
-								$mapping[ $fieldId ] = $field['name'];
-						}
-				}
-
-				return $mapping;
-		}
-
-		/**
-		 * Create an event
-		 *
-		 * @param Request $request
-		 *
-		 * @return JsonResponse
-		 * @throws Exception
-		 */
-		public function createEvent( Request $request ) {
-				try {
-						$validatedData = $request->validate( [
-								'title'        => 'required',
-								'start'        => 'required|date',
-								'end'          => 'required|date',
-								'location'     => 'nullable',
-								'body'         => 'nullable',
-								'calendarId'   => 'required',
-								'customFields' => 'nullable',
-						] );
-				} catch ( Exception $e ) {
-						return response()->json( [ 'error' => $e->getMessage() ], 400 );
-				}
-
-				$calendar = Calendar::find( $validatedData['calendarId'] );
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				$userId = $this->requireAuthUserId();
-
-				$customFieldsData      = $validatedData['customFields'] ?? [];
-				$customFields          = $calendar->custom_fields['fields'] ?? [];
-				$processedCustomFields = [
-						'author_id' => $userId,
-				];
-
-				foreach ( $customFields as $field ) {
-						$fieldId = 'custom_field_' . $field['id'];
-						if ( isset( $customFieldsData[ $fieldId ] ) ) {
-								$processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
-						} else if ( $field['required'] ) {
-								return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
-						}
-				}
-
-				$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-				$end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-				if ( $start->getTimestamp() === $end->getTimestamp() ) {
-						$end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
-				}
-
-				$isAllDay = DateTimeRange::isAllDay( $start, $end );
-
-				if ( $calendar->type === 'normal' ) {
-						$calendarItem = new CalendarItem();
-
-						$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-						$calendarItem->author_id   = $userId;
-						$calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
-						$calendarItem->start       = $start ?? Carbon::now();
-						$calendarItem->end         = $end ?? Carbon::now()->addHour();
-						$calendarItem->is_all_day  = $isAllDay ?? false;
-									$calendarItem->is_private  = false;
-									$calendarItem->is_read_only = false;
-									$calendarItem->state       = 'active';
-						$calendarItem->is_private  = $validatedData['is_private'] ?? false;
-						$calendarItem->state       = $validatedData['state'] ?? 'active';
-
-						$calendarItem->location      = $validatedData['location'] ?? '';
-						$calendarItem->body          = $validatedData['body'] ?? '';
-						$calendarItem->custom_fields = $processedCustomFields ?? [];
-
-						$calendarItem->save();
-				} else if ( $calendar->type === 'caldav' ) {
-						$fullUrl = $calendar->custom_fields['url'] ?? '';
-
-						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-								return response()->json( [
-										'status'  => 'error',
-										'message' => 'CalDAV calendar is not properly configured (missing URL).',
-								], 422 );
-						}
-
-						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-						$uid = $this->GUID();
-
-						if ( ! is_array( $validatedData['body'] ) ) {
-								$validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
-						}
-
-						$validatedData['body']['custom_fields'] = $processedCustomFields;
-
-						// Add mapping for used custom fields
-						$validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-								$calendar->custom_fields,
-								$processedCustomFields
-						);
-
-						$response = $caldavClient->createEvent(
-								$remainingUrl,
-								$uid,
-								$validatedData['title'],
-								$validatedData['body'],
-								$start,
-								$end,
-								$isAllDay,
-								$validatedData['location']
-						);
-
-						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-								Log::error( 'Error creating event', $response );
-
-								return response()->json( [ 'error' => 'Error creating event' ], 500 );
-						}
-
-						$calendar->getExternalContent( true );
-				}
-
-				return response()->json( [ 'ok' => true, 'message' => 'Event created successfully' ] );
-		}
-
-		private function processTemplate(
-				string        $template,
-				?Conversation $conversation,
-				Calendar      $calendar,
-				array         $customFields = []
-		): string {
-				if ( ! $conversation ) {
-						return $template;
-				}
-
-				$result = str_replace( '{{title}}', $conversation->subject, $template );
-
-				// Get the field name mapping from calendar's custom fields configuration
-				$fieldMapping = [];
-
-				if ( ! empty( $calendar->custom_fields['fields'] ) ) {
-						foreach ( $calendar->custom_fields['fields'] as $field ) {
-								$fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
-						}
-				}
-
-				// Process custom fields using the mapping
-				foreach ( $customFields as $fieldId => $value ) {
-						if ( is_array( $value ) ) {
-								$value = implode( ', ', $value );
-						}
-
-						if ( isset( $fieldMapping[ $fieldId ] ) ) {
-								$fieldName = $fieldMapping[ $fieldId ];
-								$result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
-						}
-				}
-
-
-
-				$result = str_replace( '{{title}}', $conversation->subject, $template );
-
-				// Get the field name mapping from calendar's custom fields configuration
-				$fieldMapping = [];
-
-				if ( ! empty( $calendar->custom_fields['fields'] ) ) {
-						foreach ( $calendar->custom_fields['fields'] as $field ) {
-								$fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
-						}
-				}
-
-				// Process custom fields using the mapping
-				foreach ( $customFields as $fieldId => $value ) {
-						if ( is_array( $value ) ) {
-								$value = implode( ', ', $value );
-						}
-
-						if ( isset( $fieldMapping[ $fieldId ] ) ) {
-								$fieldName = $fieldMapping[ $fieldId ];
-								$result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
-						}
-				}
-
-				return $result;
-		}
-
-
-		/**
-		 * Create an event from a conversation
-		 *
-		 * @param int $conversation
-		 * @param Request $request
-		 *
-		 * @return JsonResponse
-		 * @throws Exception
-		 */
-		public function createEventFromConversation( int $conversation, Request $request ) {
-				try {
-						$validatedData = $request->validate( [
-								'title'        => 'required|nullable',
-								'start'        => 'required|date',
-								'end'          => 'required|date|after:start',
-								'location'     => 'nullable',
-								'body'         => 'nullable',
-								'calendarId'   => 'required',
-								'customFields' => 'nullable',
-						] );
-				} catch ( Exception $e ) {
-						return response()->json( [ 'error' => $e->getMessage() ], 400 );
-				}
-
-				$calendar = Calendar::find( $validatedData['calendarId'] );
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				$userId = $this->requireAuthUserId();
-
-				$conversationObj = Conversation::find( $conversation );
-
-				$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-				$end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-				if ( $start->getTimestamp() === $end->getTimestamp() ) {
-						$end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
-				}
-				$isAllDay = DateTimeRange::isAllDay( $start, $end );
-
-				$customFieldsData      = $validatedData['customFields'] ?? [];
-				$customFields          = $calendar->custom_fields['fields'] ?? [];
-				$processedCustomFields = [];
-
-				foreach ( $customFields as $field ) {
-						$fieldId = 'custom_field_' . $field['id'];
-						if ( isset( $customFieldsData[ $fieldId ] ) ) {
-								$processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
-						} else if ( $field['required'] ) {
-								return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
-						}
-				}
-
-				if ( empty( $calendar->title_template ) ) {
-						$calendar->title_template = $request->input( 'title' );
-				}
-
-				$uid = null;
-				if ( $calendar->type === 'normal' ) {
-						$calendarItem = new CalendarItem();
-
-						$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-						$calendarItem->author_id   = $userId;
-						$calendarItem->title       = $this->processTemplate(
-								$calendar->title_template,
-								$conversationObj,
-								$calendar,
-								$processedCustomFields ?? []
-						);
-						$calendarItem->start       = $start ?? Carbon::now();
-						$calendarItem->end         = $end ?? Carbon::now()->addHour();
-						$calendarItem->is_all_day  = $isAllDay ?? false;
-									$calendarItem->is_private  = false;
-									$calendarItem->is_read_only = false;
-									$calendarItem->state       = 'active';
-						$calendarItem->is_private  = false;
-						$calendarItem->state       = 'active';
-						$calendarItem->location    = $validatedData['location'] ?? '';
-						$calendarItem->body        = $validatedData['body'] ?? '';
-
-						// Merge all custom fields safely
-						$customFields = $calendarItem->custom_fields;
-						if ( ! is_array( $customFields ) ) {
-								$customFields = [];
-						}
-
-						$mergedCustomFields = array_merge(
-								$customFields,
-								[
-										'conversation_id' => $conversation,
-										'author_id'       => $userId,
-								],
-								$processedCustomFields ?? []
-						);
-
-						$calendarItem->custom_fields = $mergedCustomFields;
-
-						$calendarItem->save();
-						$uid = $calendarItem->id;
-				} else if ( $calendar->type === 'caldav' ) {
-						$fullUrl = $calendar->custom_fields['url'] ?? '';
-
-						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-								return response()->json( [
-										'status'  => 'error',
-										'message' => 'CalDAV calendar is not properly configured (missing URL).',
-								], 422 );
-						}
-
-						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-						$uid = $this->GUID();
-
-						if ( ! is_array( $validatedData['body'] ) ) {
-								$validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
-						}
-
-						// Merge all custom fields
-						$mergedCustomFields = array_merge( [
-								'conversation_id' => $conversation,
-								'author_id'       => $userId,
-						], $processedCustomFields );
-
-						$validatedData['body']['custom_fields'] = $mergedCustomFields;
-
-						// Add mapping for used custom fields
-						$validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-								$calendar->custom_fields,
-								$mergedCustomFields
-						);
-
-						$response = $caldavClient->createEvent(
-								$remainingUrl,
-								$uid,
-								$this->processTemplate( $calendar->title_template, Conversation::find( $conversation ), $calendar, $processedCustomFields ),
-								$validatedData['body'],
-								$start,
-								$end,
-								$isAllDay,
-								$validatedData['location']
-						);
-
-						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-								Log::error( 'Error creating event', $response );
-
-								return response()->json( [ 'error' => 'Error creating event' ], 500 );
-						}
-
-						$calendar->getExternalContent( true );
-				}
-
-				if ( $uid !== null ) {
-						$conversation = Conversation::find( $conversation );
-						if ( $conversation !== null ) {
-								$action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
-								$created_by_user_id = $userId;
-
-								// Store the event UID for better permalink support
-								$meta = [
-										'calendar_item_id' => $uid,
-										'calendar_id'      => $calendar->id,
-										'calendar_type'    => $calendar->type,
-										'start'            => ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) )->format( DATE_ATOM ),
-								];
-
-								// For external calendars, also store the event UID
-								if ( $calendar->type === 'caldav' || $calendar->type === 'ics' ) {
-										$meta['event_uid'] = $uid;
-								}
-
-								Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
-										'user_id'            => $conversation->user_id,
-										'created_by_user_id' => $created_by_user_id,
-										'action_type'        => $action_type,
-										'source_via'         => Thread::PERSON_USER,
-										'source_type'        => Thread::SOURCE_TYPE_WEB,
-										'meta'               => $meta,
-								] );
-						}
-				}
-
-				return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
-		}
-
-		/**
-		 * Get a calendar
-		 *
-		 * @param int $id
-		 *
-		 * @return JsonResponse
-		 */
-		public function getCalendar( $id ) {
-				$calendar = Calendar::find( $id );
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				// Ensure we never return stale principals to the settings UI
-				$clean = $this->sanitizePermissions( $calendar->permissions );
-				if ( $clean !== ( $calendar->permissions ?? [] ) ) {
-					$calendar->permissions = $clean;
-					$calendar->save();
-				}
-
-				return response()->json( $calendar );
-		}
-
-		/**
-		 * Get a single event by ID - optimized endpoint for permalinks
-		 *
-		 * @param string $eventId The event ID to retrieve
-		 *
-		 * @return JsonResponse
-		 */
-		public function getEventById( string $eventId ): JsonResponse {
-				try {
-						// Check if tables exist first
-						if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
-								return response()->json( [ 'error' => 'Calendar module not properly initialized' ], 500 );
-						}
-
-						$calendars = Calendar::all();
-
-						foreach ( $calendars as $calendar ) {
-								if ( $calendar->enabled === false ) {
-										continue;
-								}
-
-								$permissions = $calendar->permissionsForCurrentUser();
-								if ( $permissions === null || ! $permissions['showInCalendar'] ) {
-										continue;
-								}
-
-								// For normal calendars, try to find the specific event by ID only
-								if ( $calendar->type === 'normal' ) {
-										$event = CalendarItem::where( 'calendar_id', $calendar->id )
-										                     ->where( 'id', $eventId )
-										                     ->first();
-
-										if ( $event ) {
-												$eventData = json_decode( $event->toJson(), true );
-
-												// Ensure calendar ID is present
-												$eventData['calendarId'] = $calendar->id;
-
-												// Generate mapping for used custom fields
-												if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
-														$eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-																$calendar->custom_fields,
-																$eventData['custom_fields']
-														);
-												}
-
-												// Set default timezone
-												$defaultTimezone    = config( 'app.timezone' );
-												$eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )
-														->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-												$eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )
-														->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-
-												// Ensure IDs are set
-												if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
-														$eventData['id'] = $eventData['uid'];
-												}
-												if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
-														$eventData['uid'] = $eventData['id'];
-												}
-												if ( empty( $eventData['title'] ) ) {
-														$eventData['title'] = '';
-												}
-
-												return response()->json( $eventData );
-										}
-								}
-
-								// For external calendars, use optimized single event lookup
-								if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
-										try {
-												$event = $calendar->findEventById( $eventId );
-
-												if ( $event ) {
-														// Add calendar ID to the event data
-														$event['calendarId']  = $calendar->id;
-														$event['calendar_id'] = $calendar->id;
-
-														// Generate mapping for used custom fields
-														if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
-																$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-																		$calendar->custom_fields,
-																		$event['custom_fields']
-																);
-														}
-
-														// Ensure timezone conversion is done
-														$defaultTimezone = config( 'app.timezone' );
-														$event['start']  = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )
-																->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-														$event['end']    = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )
-																->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-
-														return response()->json( $event );
-												}
-										} catch ( \Exception $e ) {
-												// Log and continue checking other calendars
-												\Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
-										}
-								}
-						}
-
-						// Event not found in any calendar
-						return response()->json( [ 'error' => 'Event not found' ], 404 );
-
-				} catch ( \Exception $e ) {
-						\Log::error( 'Error in getEventById: ' . $e->getMessage() );
-
-						return response()->json( [ 'error' => 'Failed to retrieve event' ], 500 );
-				}
-		}
-
-		/**
-		 * Create an event from an attachment
-		 *
-		 * @param Request $request
-		 *
-		 * @return JsonResponse
-		 * @throws Exception
-		 */
-		public function createEventFromAttachment( Request $request ) {
-				try {
-						$validatedData = $request->validate( [
-								'attachmentId'   => 'required',
-								'conversationId' => 'required',
-								'calendarId'     => 'required',
-						] );
-				} catch ( Exception $e ) {
-						return response()->json( [ 'error' => $e->getMessage() ], 400 );
-				}
-
-				$calendar = Calendar::find( $validatedData['calendarId'] );
-				if ( ! $calendar ) {
-						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-				}
-
-				$userId = $this->requireAuthUserId();
-
-				$conversation = Conversation::find( $validatedData['conversationId'] );
-				if ( ! $conversation ) {
-						return response()->json( [ 'error' => 'Conversation not found' ], 404 );
-				}
-
-				$attachment = Attachment::find( $validatedData['attachmentId'] );
-				if ( ! $attachment ) {
-						return response()->json( [ 'error' => 'Attachment not found' ], 404 );
-				}
-				$file = $attachment->getLocalFilePath();
-
-				$ical = new ICal( $file );
-				/** @var Event[] $events */
-				$events = $ical->events();
-
-				$refetchCalendarIds = [];
-
-				//add conversation url to body
-				$conversationUrl = route( 'conversations.view', [ 'id' => $conversation->id ] );
-
-				foreach ( $events as $event ) {
-						$start = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtstart_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
-						if ( ! empty( $event->dtend ) ) {
-								$end = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtend_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
-						} else {
-								if ( ! empty( $event->duration ) ) {
-										$end = $start->add( new DateInterval( $event->duration ) );
-								} else {
-										$end = $start->add( new DateInterval( 'PT1H' ) );
-								}
-						}
-						if ( $start->getTimestamp() === $end->getTimestamp() ) {
-								$end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
-						}
-						$isAllDay = DateTimeRange::isAllDay( $start, $end );
-
-						if ( $calendar->type === 'normal' ) {
-								$calendarItem = new CalendarItem();
-
-								$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-								$calendarItem->author_id   = $userId;
-								$calendarItem->title       = $event->summary ?? 'Untitled Event';
-								$calendarItem->start       = $start ?? Carbon::now();
-								$calendarItem->end         = $end ?? Carbon::now()->addHour();
-								$calendarItem->is_all_day  = $isAllDay ?? false;
-									$calendarItem->is_private  = false;
-									$calendarItem->is_read_only = false;
-									$calendarItem->state       = 'active';
-								$calendarItem->location    = $event->location ?? '';
-								$calendarItem->body        = $event->description ?? '';
-
-								// Merge custom fields safely
-								$customFields = $calendarItem->custom_fields;
-								if ( ! is_array( $customFields ) ) {
-										$customFields = [];
-								}
-
-								$customFields['conversation_id'] = $conversation ? $conversation->id : null;
-								$customFields['author_id']       = $userId;
-
-								$calendarItem->custom_fields = $customFields;
-
-								$calendarItem->save();
-								$uid = $calendarItem->id;
-						} else if ( $calendar->type === 'caldav' ) {
-								$fullUrl      = $calendar->custom_fields['url'];
-								$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-								$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-								$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-								$uid = $event->uid ?? $this->GUID();
-
-								$description = [
-										'body'          => empty( $event->description ) ? '-' : $event->description,
-										'custom_fields' => [
-												'conversation_id' => $conversation->id,
-												'author_id'       => $userId,
-										],
-								];
-
-								$response = $caldavClient->createEvent( $remainingUrl, $uid, $event->summary, $description, $start, $end, $isAllDay, $event->location );
-								if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-										Log::error( 'Error creating event', $response );
-
-										return response()->json( [ 'error' => 'Error creating event', $response['body'], 'data' => [ $uid, $event->summary, $description, $start, $end, $event->location ] ], 500 );
-								}
-								$refetchCalendarIds[] = $calendar->id;
-						}
-
-						if ( $uid !== null ) {
-								$action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
-								$created_by_user_id = $userId;
-								Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
-										'user_id'            => $conversation->user_id,
-										'created_by_user_id' => $created_by_user_id,
-										'action_type'        => $action_type,
-										'source_via'         => Thread::PERSON_USER,
-										'source_type'        => Thread::SOURCE_TYPE_WEB,
-										'meta'               => [
-												'calendar_item_id' => $uid,
-												'calendar_id'      => $calendar->id,
-												'start'            => $start->format( DATE_ATOM ),
-										],
-								] );
-						}
-				}
-
-				$refetchCalendarIds = array_values( array_unique( $refetchCalendarIds ) );
-				foreach ( $refetchCalendarIds as $refetchCalendarId ) {
-						UpdateExternalCalendarJob::dispatch( $refetchCalendarId );
-				}
-
-				return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
-		}
+        /**
+         * Prefix used to namespace Team principals in permissions.
+         *
+         * Why: Teams and Users can share the same numeric ID space in different tables/modules.
+         * Storing permissions keyed only by numbers can cause silent overwrites or pruning.
+         */
+        private const TEAM_PRINCIPAL_PREFIX = 't:';
+
+        /**
+         * Teams module compatibility: depending on FreeScout/Teams versions, getTeams()
+         * may return Eloquent models or plain arrays. Normalize access.
+         */
+        private function teamId( $team ): ?string {
+            if ( is_object( $team ) && isset( $team->id ) ) {
+                return (string) $team->id;
+            }
+            if ( is_array( $team ) && isset( $team['id'] ) ) {
+                return (string) $team['id'];
+            }
+            return null;
+        }
+
+        private function teamLabel( $team ): string {
+            // Teams module historically uses "getFirstName()" (Team model extends User-ish API)
+            if ( is_object( $team ) ) {
+                if ( method_exists( $team, 'getFirstName' ) ) {
+                    return (string) $team->getFirstName();
+                }
+                if ( isset( $team->name ) ) {
+                    return (string) $team->name;
+                }
+                if ( isset( $team->title ) ) {
+                    return (string) $team->title;
+                }
+            }
+            if ( is_array( $team ) ) {
+                return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
+            }
+            return '';
+        }
+        /**
+         * Build a map of all currently valid "principals" that can appear in calendar permissions.
+         *
+         * Principals are:
+         *  - Active users (App\\User)
+         *  - Teams (if the Teams module is installed)
+         *
+         * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
+         */
+            private function getValidPrincipals(): array {
+                $users = [];
+                $teams = [];
+
+                // Teams (optional module)
+                if ( class_exists( Teams::class ) ) {
+                    // Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
+                    // Casting a Collection to array yields internal properties, not items, which would
+                    // make us think there are no teams and prune all team permissions on save.
+                    foreach ( Teams::getTeams( true ) as $team ) {
+                        $teamId = $this->teamId( $team );
+                        if ( $teamId === null ) {
+                            continue;
+                        }
+                        $teams[$teamId] = true;
+                    }
+                }
+
+                    // Active users
+                    $allUsers = User::where( 'status', User::STATUS_ACTIVE )
+                    ->remember( Helper::cacheTime() )
+                    ->get();
+                    foreach ( $allUsers as $user ) {
+                        $users[(string) $user->id] = true;
+                    }
+
+                    // Canonical permission keys: users are numeric strings; teams are namespaced.
+                    $valid = $users;
+                    foreach ( array_keys( $teams ) as $teamId ) {
+                        $valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
+                    }
+
+                    return [
+                        'users' => $users,
+                        'teams' => $teams,
+                        'valid' => $valid,
+                    ];
+        }
+
+        private function isTeamKey( string $key ): bool {
+            return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
+            || str_starts_with( $key, 'team_' )
+            || str_starts_with( $key, 'team:' );
+        }
+
+        private function normalizeTeamKey( string $key ): ?string {
+            if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
+                $id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
+                return ctype_digit( $id ) ? $id : null;
+            }
+            if ( str_starts_with( $key, 'team_' ) ) {
+                $id = substr( $key, 5 );
+                return ctype_digit( $id ) ? $id : null;
+            }
+            if ( str_starts_with( $key, 'team:' ) ) {
+                $id = substr( $key, 5 );
+                return ctype_digit( $id ) ? $id : null;
+            }
+            return null;
+        }
+
+        /**
+         * Remove permission rows for principals (teams/users) that no longer exist.
+         * This fixes stale permission keys after deleting a team (Teams module) or deactivating a user.
+         *
+         * @param array|null $permissions
+         * @return array
+         */
+        private function sanitizePermissions( $permissions ): array {
+            if ( ! is_array( $permissions ) ) {
+                return [];
+            }
+
+            $principals = $this->getValidPrincipals();
+            $valid      = $principals['valid'];
+            $clean = [];
+
+            foreach ( $permissions as $id => $permission ) {
+                $key = (string) $id;
+
+                // Canonicalize team keys.
+                if ( $this->isTeamKey( $key ) ) {
+                    $teamId = $this->normalizeTeamKey( $key );
+                    if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
+                        continue;
+                    }
+                    $key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
+                } else if ( ctype_digit( $key ) ) {
+                    // Backward compatibility: legacy numeric team IDs.
+                    // Prefer users when ambiguous (user ID and team ID overlap).
+                    if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
+                        $key = self::TEAM_PRINCIPAL_PREFIX . $key;
+                    }
+                }
+
+                if ( ! isset( $valid[$key] ) ) {
+                    continue;
+                }
+
+                $clean[$key] = [
+                    'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
+                    'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
+                    'createItems'     => (bool) ( $permission['createItems'] ?? false ),
+                    'editItems'       => (bool) ( $permission['editItems'] ?? false ),
+                ];
+            }
+
+            return $clean;
+        }
+
+        /**
+         * Normalize permissions payload from the UI.
+         *
+         * The UI may send permissions either as:
+         *  - an associative array keyed by principal id (preferred), or
+         *  - a numerically indexed list of objects with an 'id' field.
+         *
+         * Without normalization, numeric indexes (0,1,2,...) get treated as IDs and
+         * sanitizePermissions() prunes everything as "invalid", making changes appear not to save.
+         *
+         * @param mixed $raw
+         * @return array
+         */
+        private function normalizePermissionsInput( $raw ): array {
+            if ( ! is_array( $raw ) ) {
+                return [];
+            }
+
+            // If it already looks like an associative map keyed by IDs, keep as-is.
+            $keys = array_keys( $raw );
+            $allNumeric = true;
+            foreach ( $keys as $k ) {
+                $kStr = (string) $k;
+                if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
+                    $allNumeric = false;
+                    break;
+                }
+            }
+            if ( ! $allNumeric ) {
+                return $raw;
+            }
+
+            // Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
+            $map = [];
+            foreach ( $raw as $row ) {
+                if ( is_array( $row ) && ! empty( $row['id'] ) ) {
+                    $map[(string) $row['id']] = $row;
+                }
+            }
+
+            return $map;
+        }
+
+
+        private function requireAuthUserId(): int {
+                $userId = auth()->id();
+                if ( ! $userId ) {
+                        abort( 401, 'Unauthenticated' );
+                }
+
+                return (int) $userId;
+        }
+
+        /**
+         * Get users for the settings
+         *
+         * @return JsonResponse A JSON response containing an array of user objects
+         */
+        public function getUsers(): JsonResponse {
+                $response = [
+                        'results' => [],
+                ];
+
+                // Get all teams
+                $allTeams = [];
+                if ( class_exists( Teams::class ) ) {
+                        $allTeams = Teams::getTeams( true );
+                }
+
+                // Get all users that are active
+                $allUsers = User::where( 'status', User::STATUS_ACTIVE )
+                                ->remember( Helper::cacheTime() )
+                                ->get();
+
+                // Add team members to the response array
+                /** @var Team $team */
+                foreach ( $allTeams as $team ) {
+                    $teamId = $this->teamId( $team );
+                    if ( $teamId === null ) {
+                        continue;
+                    }
+                        $response['results'][] = [
+                        'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
+                        'text' => 'Team: ' . $this->teamLabel( $team ),
+                        ];
+                }
+
+                // Add users to the response array
+                /** @var User $user */
+                foreach ( $allUsers as $user ) {
+                        $response['results'][] = [
+                                'id'   => (string) $user->id,
+                                'text' => $user->getFullName(),
+                        ];
+                }
+
+                return response()->json( $response );
+        }
+
+        /**
+         * Get calendars for the settings
+         *
+         * @return JsonResponse A JSON response containing an array of calendar objects
+         */
+        public function getCalendars(): JsonResponse {
+                $calendars = Calendar::all();
+
+                // Prune stale permission keys (e.g. deleted Teams principals) to avoid broken UI and errors.
+                foreach ( $calendars as $calendar ) {
+                    $clean = $this->sanitizePermissions( $calendar->permissions );
+                    if ( $clean !== ( $calendar->permissions ?? [] ) ) {
+                        $calendar->permissions = $clean;
+                        $calendar->save();
+                    }
+                }
+
+                return response()->json( $calendars );
+        }
+
+        /**
+         * Update a calendar
+         *
+         * @param int $id The ID of the calendar to update
+         * @param Request $request The request object
+         *
+         * @return JsonResponse A JSON response containing the updated calendar object
+         */
+        public function updateCalendar( int $id, Request $request ) {
+                $calendar = Calendar::find( $id );
+
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                $calendar->name           = $request->input( 'name' );
+                $calendar->color          = $request->input( 'color' );
+                $calendar->title_template = $request->input( 'title_template' );
+
+                $customFields            = $request->input( 'custom_fields', [] );
+                $calendar->custom_fields = $this->validateCustomFields( $customFields );
+
+                if ( $calendar->type === 'ics' ) {
+                        $calendar->custom_fields = array_merge( $calendar->custom_fields, [
+                                'url'     => $request->input( 'url' ),
+                                'refresh' => $request->input( 'refresh' ),
+                        ] );
+                } else if ( $calendar->type === 'caldav' ) {
+                        $calendar->custom_fields = array_merge( $calendar->custom_fields, [
+                                'url'      => $request->input( 'url' ),
+                                'username' => $request->input( 'username' ),
+                                'password' => $request->input( 'password' ),
+                                'refresh'  => $request->input( 'refresh' ),
+                        ] );
+                }
+                $permissions = [];
+                $rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
+                foreach ( $rawPermissions as $id => $permission ) {
+                        $permissions[ $id ] = [
+                                'showInDashboard' => $permission['showInDashboard'] ?? false,
+                                'showInCalendar'  => $permission['showInCalendar'] ?? false,
+                                'createItems'     => $permission['createItems'] ?? false,
+                                'editItems'       => $permission['editItems'] ?? false,
+                        ];
+                }
+                $calendar->permissions = $this->sanitizePermissions( $permissions );
+
+                $calendar->save();
+
+                return response()->json( $calendar );
+        }
+
+        /**
+         * Validate and sanitize custom fields
+         *
+         * @param array $customFields The custom fields to validate
+         *
+         * @return array The validated and sanitized custom fields
+         */
+        private function validateCustomFields( array $customFields ): array {
+                if ( empty( $customFields['fields'] ) || ! is_array( $customFields['fields'] ) ) {
+                        return [ 'fields' => [] ];
+                }
+                $validatedFields = [];
+
+                foreach ( $customFields['fields'] as $field ) {
+                        $validatedField = [
+                                'id'       => $field['id'] ?? null,
+                                'name'     => strip_tags( $field['name'] ?? '' ),
+                                'type'     => in_array( $field['type'], [ 'text', 'number', 'dropdown', 'boolean', 'multiselect', 'date', 'email', 'source' ] ) ? $field['type'] : 'text',
+                                'required' => (bool) ( $field['required'] ?? false ),
+                        ];
+
+                        if ( $validatedField['type'] === 'source' ) {
+                                $validatedField['required'] = false;
+                        }
+
+                        if ( in_array( $field['type'], [ 'dropdown', 'multiselect' ] ) ) {
+                                $options = $field['options'] ?? [];
+                                if ( ! is_array( $options ) ) {
+                                        $options = explode( ',', $options );
+                                }
+                                $validatedField['options'] = array_map( 'trim', array_map( fn( $opt ) => strip_tags( (string) $opt ), $options ) );
+                        }
+
+                        $validatedFields[] = $validatedField;
+                }
+
+                return [ 'fields' => $validatedFields ];
+        }
+
+        /**
+         * Create a new calendar
+         *
+         * @param Request $request The request object
+         *
+         * @return JsonResponse A JSON response containing the created calendar object
+         */
+        public function addCalendar( Request $request ) {
+                $calendar = new Calendar();
+
+                $calendar->name           = strip_tags( $request->input( 'name' ) ?? 'Default Calendar' );
+                $calendar->color          = $request->input( 'color' );
+                $calendar->type           = $request->input( 'type' );
+                $calendar->title_template = $request->input( 'title_template' );
+
+                $customFields            = $request->input( 'custom_fields', [] );
+                $calendar->custom_fields = $this->validateCustomFields( $customFields );
+
+                if ( $calendar->type === 'ics' ) {
+                        $calendar->custom_fields = [
+                                'url'     => $request->input( 'url' ),
+                                'refresh' => $request->input( 'refresh' ),
+                        ];
+                } else if ( $calendar->type === 'caldav' ) {
+                        $calendar->custom_fields = [
+                                'url'      => $request->input( 'url' ),
+                                'username' => $request->input( 'username' ),
+                                'password' => $request->input( 'password' ),
+                                'refresh'  => $request->input( 'refresh' ),
+                        ];
+                }
+                $permissions = [];
+                $rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
+                foreach ( $rawPermissions as $id => $permission ) {
+                        $permissions[ $id ] = [
+                                'showInDashboard' => $permission['showInDashboard'],
+                                'showInCalendar'  => $permission['showInCalendar'],
+                                'createItems'     => $permission['createItems'] ?? false,
+                                'editItems'       => $permission['editItems'] ?? false,
+                        ];
+                }
+                $calendar->permissions = $this->sanitizePermissions( $permissions );
+
+                $calendar->save();
+
+                return response()->json( $calendar );
+        }
+
+        /**
+         * Delete a calendar
+         *
+         * @param int $id The ID of the calendar to delete
+         *
+         * @return JsonResponse A JSON response indicating the deletion result
+         * @throws Exception
+         */
+        public function deleteCalendar( int $id ): JsonResponse {
+                $calendar = Calendar::find( $id );
+
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
+                        //remove temporary ics file
+                        $filename = $calendar->getTemporaryFile();
+                        if ( file_exists( $filename ) ) {
+                                unlink( $filename );
+                        }
+                } else {
+                        //remove all calendar items for this calendar
+                        CalendarItem::where( 'calendar_id', $calendar->id )->delete();
+                }
+
+                $calendar->delete();
+
+                return response()->json( [ 'ok' => true, 'message' => 'Calendar deleted successfully' ] );
+        }
+
+
+        /**
+         * Get events
+         *
+         * This method handles both date range queries and specific event ID lookups.
+         * For event ID lookups on external calendars, it uses an optimized approach
+         * that avoids loading unnecessary date ranges, improving performance for large calendars.
+         *
+         * @param Request $request The request containing either date range (start/end) or eventId
+         *
+         * @return JsonResponse Array of events matching the criteria
+         * @throws Exception
+         */
+        public function getEvents( Request $request ) {
+                // Special case: If looking for a specific event by ID
+                $eventId = $request->input( 'eventId' );
+                if ( $eventId ) {
+                        try {
+                                // Check if tables exist first
+                                if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
+                                        return response()->json( [] );
+                                }
+
+                                $events    = [];
+                                $calendars = Calendar::all();
+
+                                foreach ( $calendars as $calendar ) {
+                                        if ( $calendar->enabled === false ) {
+                                                continue;
+                                        }
+                                        $permissions = $calendar->permissionsForCurrentUser();
+                                        if ( $permissions === null ) {
+                                                continue;
+                                        }
+                                        if ( $permissions['showInCalendar'] !== true ) {
+                                                continue;
+                                        }
+
+                                        // For normal calendars, try to find the specific event
+                                        if ( $calendar->type === 'normal' ) {
+                                                $event = CalendarItem::where( 'uid', $eventId )
+                                                                     ->orWhere( 'id', $eventId )
+                                                                     ->where( 'calendar_id', $calendar->id )
+                                                                     ->first();
+
+                                                if ( $event ) {
+                                                        // Found the event, return it
+                                                        $eventData = json_decode( $event->toJson(), true );
+
+                                                        // Generate mapping for used custom fields
+                                                        if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
+                                                                $eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                                                        $calendar->custom_fields,
+                                                                        $eventData['custom_fields']
+                                                                );
+                                                        }
+
+                                                        // Set default timezone
+                                                        $defaultTimezone    = config( 'app.timezone' );
+                                                        $eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                                                        $eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+
+                                                        if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
+                                                                $eventData['id'] = $eventData['uid'];
+                                                        }
+                                                        if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
+                                                                $eventData['uid'] = $eventData['id'];
+                                                        }
+                                                        if ( empty( $eventData['title'] ) ) {
+                                                                $eventData['title'] = '';
+                                                        }
+
+                                                        $events[] = $eventData;
+                                                        break;
+                                                }
+                                        }
+
+                                        // For external calendars, use optimized single event lookup
+                                        if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
+                                                try {
+                                                        // Use the new optimized method for finding a single event
+                                                        $event = $calendar->findEventById( $eventId );
+
+                                                        if ( $event ) {
+                                                                // Found the event, prepare it for return
+                                                                if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
+                                                                        $event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                                                                $calendar->custom_fields,
+                                                                                $event['custom_fields']
+                                                                        );
+                                                                }
+                                                                $events[] = $event;
+                                                                break;
+                                                        }
+                                                } catch ( \Exception $e ) {
+                                                        // Log and continue - we don't want a single calendar to break the entire request
+                                                        \Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
+                                                }
+                                        }
+                                }
+
+                                // Restore timezones
+                                $defaultTimezone = config( 'app.timezone' );
+                                foreach ( $events as &$event ) {
+                                        $event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                                        $event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                                }
+                                unset( $event );
+
+                                return response()->json( $events );
+                        } catch ( \Exception $e ) {
+                                // Log the error but return a valid response
+                                \Log::error( 'Error in getEvents by ID: ' . $e->getMessage() );
+
+                                return response()->json( [] );
+                        }
+                }
+
+                try {
+                        // Regular date range query
+                        $request->validate( [
+                                'start' => 'required|date',
+                                'end'   => 'required|date',
+                        ] );
+
+                        // Check if tables exist first
+                        if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
+                                return response()->json( [] );
+                        }
+
+                        $defaultTimezone = config( 'app.timezone' );
+
+                        $start = ( new DateTimeImmutable( $request->input( 'start' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                        $end   = ( new DateTimeImmutable( $request->input( 'end' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+
+                        $calendars = Calendar::all();
+                        $events    = [];
+
+                        foreach ( $calendars as $calendar ) {
+                                if ( $calendar->enabled === false ) {
+                                        continue;
+                                }
+                                $permissions = $calendar->permissionsForCurrentUser();
+                                if ( $permissions === null ) {
+                                        continue;
+                                }
+                                if ( $permissions['showInCalendar'] !== true ) {
+                                        continue;
+                                }
+
+                                try {
+                                        $calendarEvents = $calendar->events( $start, $end );
+                                        foreach ( $calendarEvents as $event ) {
+                                                // Generate mapping for used custom fields
+                                                if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
+                                                        $event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                                                $calendar->custom_fields,
+                                                                $event['custom_fields']
+                                                        );
+                                                }
+                                                $events[] = $event;
+                                        }
+                                } catch ( \Exception $e ) {
+                                        // Log and continue - we don't want a single calendar to break the entire request
+                                        \Log::error( 'Error fetching events from calendar ' . $calendar->id . ': ' . $e->getMessage() );
+                                }
+                        }
+
+                        /**
+                         * Restore timezones
+                         */
+                        foreach ( $events as &$event ) {
+                                if ( empty( $event['id'] ) && ! empty( $event['uid'] ) ) {
+                                        $event['id'] = $event['uid'];
+                                }
+                                if ( empty( $event['uid'] ) && ! empty( $event['id'] ) ) {
+                                        $event['uid'] = $event['id'];
+                                }
+                                if ( empty( $event['title'] ) ) {
+                                        $event['title'] = '';
+                                }
+
+                                $event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                                $event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                        }
+                        unset( $event );
+
+                        return response()->json( $events );
+                } catch ( \Exception $e ) {
+                        // Log the error but return a valid response
+                        \Log::error( 'Error in getEvents date range: ' . $e->getMessage() );
+
+                        return response()->json( [] );
+                }
+        }
+
+        /**
+         * Update an event
+         *
+         * @param Request $request
+         *
+         * @return JsonResponse
+         * @throws Exception
+         */
+        public function updateEvent( Request $request ) {
+                try {
+                        $validatedData = $request->validate( [
+                                'uid'          => 'required',
+                                'title'        => 'required',
+                                'start'        => 'required|date',
+                                'end'          => 'required|date|after:start',
+                                'location'     => 'nullable',
+                                'body'         => 'nullable',
+                                'calendarId'   => 'required',
+                                'customFields' => 'nullable',
+                        ] );
+                } catch ( Exception $e ) {
+                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
+                }
+
+                $calendar = Calendar::find( $validatedData['calendarId'] );
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                $customFieldsData      = $validatedData['customFields'] ?? [];
+                $customFields          = $calendar->custom_fields['fields'] ?? [];
+                $processedCustomFields = [];
+
+                foreach ( $customFields as $field ) {
+                        $fieldId = 'custom_field_' . $field['id'];
+                        if ( isset( $customFieldsData[ $fieldId ] ) ) {
+                                $processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
+                        } else if ( $field['required'] ) {
+                                return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
+                        }
+                }
+
+                if ( $calendar->type === 'normal' ) {
+                        $calendarItem = CalendarItem::where( 'id', $validatedData['uid'] )->first();
+                        if ( ! $calendarItem ) {
+                                return response()->json( [ 'error' => 'Event not found' ], 404 );
+                        }
+
+                        $calendarItem->title    = $validatedData['title'];
+                        $calendarItem->start    = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                        $calendarItem->end      = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                        $calendarItem->location = $validatedData['location'];
+                        $calendarItem->body     = $validatedData['body'] ?? '';
+                        if ( ! is_array( $calendarItem->custom_fields ) ) {
+                                $calendarItem->custom_fields = [];
+                        }
+                        $calendarItem->custom_fields = array_merge( $calendarItem->custom_fields, $processedCustomFields );
+
+                        $calendarItem->save();
+                } else if ( $calendar->type === 'caldav' ) {
+                        $fullUrl = $calendar->custom_fields['url'] ?? '';
+
+                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+                                return response()->json( [
+                                        'status'  => 'error',
+                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
+                                ], 422 );
+                        }
+
+                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+                        $start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                        $end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+
+                        if ( isset( $customFieldsData['author_id'] ) ) {
+                                $processedCustomFields['author_id'] = $customFieldsData['author_id'];
+                        }
+                        if ( isset( $customFieldsData['conversation_id'] ) ) {
+                                $processedCustomFields['conversation_id'] = $customFieldsData['conversation_id'];
+                        }
+
+                        if ( count( $processedCustomFields ) > 0 ) {
+                                if ( ! is_array( $validatedData['body'] ) ) {
+                                        $validatedData['body'] = [ 'body' => $validatedData['body'] ];
+                                }
+
+                                if ( ! isset( $validatedData['body']['custom_fields'] ) || ! is_array( $validatedData['body']['custom_fields'] ) ) {
+                                        $validatedData['body']['custom_fields'] = [];
+                                }
+
+                                $validatedData['body']['custom_fields'] = array_merge(
+                                        $validatedData['body']['custom_fields'],
+                                        $processedCustomFields
+                                );
+
+                                // Add mapping for used custom fields
+                                $validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                        $calendar->custom_fields,
+                                        $processedCustomFields
+                                );
+                        }
+
+                        $response = $caldavClient->updateEvent(
+                                $remainingUrl,
+                                $validatedData['uid'],
+                                $validatedData['title'],
+                                $validatedData['body'],
+                                $start,
+                                $end,
+                                $validatedData['location']
+                        );
+
+                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+                                Log::error( 'Error updating event', $response );
+
+                                return response()->json( [ 'error' => 'Error updating event' ], 500 );
+                        }
+
+                        $calendar->getExternalContent( true );
+                }
+
+                return response()->json( [ 'ok' => true, 'message' => 'Event updated successfully' ] );
+        }
+
+        /**
+         * Generate a GUID
+         * @return string
+         */
+        private function GUID() {
+                if ( function_exists( 'com_create_guid' ) === true ) {
+                        return trim( com_create_guid(), '{}' );
+                }
+
+                return sprintf( '%04X%04X-%04X-%04X-%04X-%04X%04X%04X', mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 16384, 20479 ), mt_rand( 32768, 49151 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ) );
+        }
+
+        /**
+         * Delete an event
+         *
+         * @param Request $request
+         *
+         * @return JsonResponse
+         * @throws Exception
+         */
+        public function deleteEvent( Request $request ) {
+                $eventId    = $request->input( 'id' );
+                $calendarId = $request->input( 'calendarId' );
+
+                $calendar = Calendar::find( $calendarId );
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                if ( $calendar->type === 'normal' ) {
+                        $calendarItem = CalendarItem::where( 'id', $eventId )->first();
+                        if ( ! $calendarItem ) {
+                                return response()->json( [ 'error' => 'Event not found' ], 404 );
+                        }
+                        $calendarItem->delete();
+                } else if ( $calendar->type === 'caldav' ) {
+                        $fullUrl = $calendar->custom_fields['url'] ?? '';
+
+                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+                                return response()->json( [
+                                        'status'  => 'error',
+                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
+                                ], 422 );
+                        }
+
+                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+                        $response = $caldavClient->deleteEvent( $remainingUrl, $eventId );
+                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+                                Log::error( 'Error deleting event', $response );
+
+                                return response()->json( [ 'error' => 'Error deleting event' ], 500 );
+                        }
+                        $calendar->getExternalContent( true );
+                }
+
+                return response()->json( [ 'ok' => true, 'message' => 'Event deleted successfully' ] );
+        }
+
+        /**
+         * Helper function to generate custom field mapping
+         *
+         * @param array $customFields Array of all possible custom fields
+         * @param array $usedCustomFields Array of used custom field values
+         *
+         * @return array Mapping of used custom field IDs to their names
+         */
+        private function generateCustomFieldMapping( array $customFields, array $usedCustomFields ): array {
+                $mapping = [];
+                $fields  = $customFields['fields'] ?? [];
+
+                foreach ( $fields as $field ) {
+                        $fieldId = 'custom_field_' . $field['id'];
+                        // Only include fields that are actually used in the item
+                        if ( isset( $usedCustomFields[ $fieldId ] ) ) {
+                                $mapping[ $fieldId ] = $field['name'];
+                        }
+                }
+
+                return $mapping;
+        }
+
+        /**
+         * Create an event
+         *
+         * @param Request $request
+         *
+         * @return JsonResponse
+         * @throws Exception
+         */
+        public function createEvent( Request $request ) {
+                try {
+                        $validatedData = $request->validate( [
+                                'title'        => 'required',
+                                'start'        => 'required|date',
+                                'end'          => 'required|date',
+                                'location'     => 'nullable',
+                                'body'         => 'nullable',
+                                'calendarId'   => 'required',
+                                'customFields' => 'nullable',
+                        ] );
+                } catch ( Exception $e ) {
+                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
+                }
+
+                $calendar = Calendar::find( $validatedData['calendarId'] );
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                $userId = $this->requireAuthUserId();
+
+                $customFieldsData      = $validatedData['customFields'] ?? [];
+                $customFields          = $calendar->custom_fields['fields'] ?? [];
+                $processedCustomFields = [
+                        'author_id' => $userId,
+                ];
+
+                foreach ( $customFields as $field ) {
+                        $fieldId = 'custom_field_' . $field['id'];
+                        if ( isset( $customFieldsData[ $fieldId ] ) ) {
+                                $processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
+                        } else if ( $field['required'] ) {
+                                return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
+                        }
+                }
+
+                $start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                $end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                if ( $start->getTimestamp() === $end->getTimestamp() ) {
+                        $end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
+                }
+
+                $isAllDay = DateTimeRange::isAllDay( $start, $end );
+
+                if ( $calendar->type === 'normal' ) {
+                        $calendarItem = new CalendarItem();
+
+                        $calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+                        $calendarItem->author_id   = $userId;
+                        $calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
+                        $calendarItem->start       = $start ?? Carbon::now();
+                        $calendarItem->end         = $end ?? Carbon::now()->addHour();
+                        $calendarItem->is_all_day  = $isAllDay ?? false;
+                                    $calendarItem->is_private  = false;
+                                    $calendarItem->is_read_only = false;
+                                    $calendarItem->state       = 'active';
+                        $calendarItem->is_private  = $validatedData['is_private'] ?? false;
+                        $calendarItem->state       = $validatedData['state'] ?? 'active';
+
+                        $calendarItem->location      = $validatedData['location'] ?? '';
+                        $calendarItem->body          = $validatedData['body'] ?? '';
+                        $calendarItem->custom_fields = $processedCustomFields ?? [];
+
+                        $calendarItem->save();
+                } else if ( $calendar->type === 'caldav' ) {
+                        $fullUrl = $calendar->custom_fields['url'] ?? '';
+
+                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+                                return response()->json( [
+                                        'status'  => 'error',
+                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
+                                ], 422 );
+                        }
+
+                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+                        $uid = $this->GUID();
+
+                        if ( ! is_array( $validatedData['body'] ) ) {
+                                $validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
+                        }
+
+                        $validatedData['body']['custom_fields'] = $processedCustomFields;
+
+                        // Add mapping for used custom fields
+                        $validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                $calendar->custom_fields,
+                                $processedCustomFields
+                        );
+
+                        $response = $caldavClient->createEvent(
+                                $remainingUrl,
+                                $uid,
+                                $validatedData['title'],
+                                $validatedData['body'],
+                                $start,
+                                $end,
+                                $isAllDay,
+                                $validatedData['location']
+                        );
+
+                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+                                Log::error( 'Error creating event', $response );
+
+                                return response()->json( [ 'error' => 'Error creating event' ], 500 );
+                        }
+
+                        $calendar->getExternalContent( true );
+                }
+
+                return response()->json( [ 'ok' => true, 'message' => 'Event created successfully' ] );
+        }
+
+        private function processTemplate(
+                string        $template,
+                ?Conversation $conversation,
+                Calendar      $calendar,
+                array         $customFields = []
+        ): string {
+                if ( ! $conversation ) {
+                        return $template;
+                }
+
+                $result = str_replace( '{{title}}', $conversation->subject, $template );
+
+                // Get the field name mapping from calendar's custom fields configuration
+                $fieldMapping = [];
+
+                if ( ! empty( $calendar->custom_fields['fields'] ) ) {
+                        foreach ( $calendar->custom_fields['fields'] as $field ) {
+                                $fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
+                        }
+                }
+
+                // Process custom fields using the mapping
+                foreach ( $customFields as $fieldId => $value ) {
+                        if ( is_array( $value ) ) {
+                                $value = implode( ', ', $value );
+                        }
+
+                        if ( isset( $fieldMapping[ $fieldId ] ) ) {
+                                $fieldName = $fieldMapping[ $fieldId ];
+                                $result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
+                        }
+                }
+
+
+
+                $result = str_replace( '{{title}}', $conversation->subject, $template );
+
+                // Get the field name mapping from calendar's custom fields configuration
+                $fieldMapping = [];
+
+                if ( ! empty( $calendar->custom_fields['fields'] ) ) {
+                        foreach ( $calendar->custom_fields['fields'] as $field ) {
+                                $fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
+                        }
+                }
+
+                // Process custom fields using the mapping
+                foreach ( $customFields as $fieldId => $value ) {
+                        if ( is_array( $value ) ) {
+                                $value = implode( ', ', $value );
+                        }
+
+                        if ( isset( $fieldMapping[ $fieldId ] ) ) {
+                                $fieldName = $fieldMapping[ $fieldId ];
+                                $result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
+                        }
+                }
+
+                return $result;
+        }
+
+
+        /**
+         * Create an event from a conversation
+         *
+         * @param int $conversation
+         * @param Request $request
+         *
+         * @return JsonResponse
+         * @throws Exception
+         */
+        public function createEventFromConversation( int $conversation, Request $request ) {
+                try {
+                        $validatedData = $request->validate( [
+                                'title'        => 'required|nullable',
+                                'start'        => 'required|date',
+                                'end'          => 'required|date|after:start',
+                                'location'     => 'nullable',
+                                'body'         => 'nullable',
+                                'calendarId'   => 'required',
+                                'customFields' => 'nullable',
+                        ] );
+                } catch ( Exception $e ) {
+                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
+                }
+
+                $calendar = Calendar::find( $validatedData['calendarId'] );
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                $userId = $this->requireAuthUserId();
+
+                $conversationObj = Conversation::find( $conversation );
+
+                $start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                $end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+                if ( $start->getTimestamp() === $end->getTimestamp() ) {
+                        $end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
+                }
+                $isAllDay = DateTimeRange::isAllDay( $start, $end );
+
+                $customFieldsData      = $validatedData['customFields'] ?? [];
+                $customFields          = $calendar->custom_fields['fields'] ?? [];
+                $processedCustomFields = [];
+
+                foreach ( $customFields as $field ) {
+                        $fieldId = 'custom_field_' . $field['id'];
+                        if ( isset( $customFieldsData[ $fieldId ] ) ) {
+                                $processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
+                        } else if ( $field['required'] ) {
+                                return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
+                        }
+                }
+
+                if ( empty( $calendar->title_template ) ) {
+                        $calendar->title_template = $request->input( 'title' );
+                }
+
+                $uid = null;
+                if ( $calendar->type === 'normal' ) {
+                        $calendarItem = new CalendarItem();
+
+                        $calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+                        $calendarItem->author_id   = $userId;
+                        $calendarItem->title       = $this->processTemplate(
+                                $calendar->title_template,
+                                $conversationObj,
+                                $calendar,
+                                $processedCustomFields ?? []
+                        );
+                        $calendarItem->start       = $start ?? Carbon::now();
+                        $calendarItem->end         = $end ?? Carbon::now()->addHour();
+                        $calendarItem->is_all_day  = $isAllDay ?? false;
+                                    $calendarItem->is_private  = false;
+                                    $calendarItem->is_read_only = false;
+                                    $calendarItem->state       = 'active';
+                        $calendarItem->is_private  = false;
+                        $calendarItem->state       = 'active';
+                        $calendarItem->location    = $validatedData['location'] ?? '';
+                        $calendarItem->body        = $validatedData['body'] ?? '';
+
+                        // Merge all custom fields safely
+                        $customFields = $calendarItem->custom_fields;
+                        if ( ! is_array( $customFields ) ) {
+                                $customFields = [];
+                        }
+
+                        $mergedCustomFields = array_merge(
+                                $customFields,
+                                [
+                                        'conversation_id' => $conversation,
+                                        'author_id'       => $userId,
+                                ],
+                                $processedCustomFields ?? []
+                        );
+
+                        $calendarItem->custom_fields = $mergedCustomFields;
+
+                        $calendarItem->save();
+                        $uid = $calendarItem->id;
+                } else if ( $calendar->type === 'caldav' ) {
+                        $fullUrl = $calendar->custom_fields['url'] ?? '';
+
+                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+                                return response()->json( [
+                                        'status'  => 'error',
+                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
+                                ], 422 );
+                        }
+
+                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+                        $uid = $this->GUID();
+
+                        if ( ! is_array( $validatedData['body'] ) ) {
+                                $validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
+                        }
+
+                        // Merge all custom fields
+                        $mergedCustomFields = array_merge( [
+                                'conversation_id' => $conversation,
+                                'author_id'       => $userId,
+                        ], $processedCustomFields );
+
+                        $validatedData['body']['custom_fields'] = $mergedCustomFields;
+
+                        // Add mapping for used custom fields
+                        $validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                $calendar->custom_fields,
+                                $mergedCustomFields
+                        );
+
+                        $response = $caldavClient->createEvent(
+                                $remainingUrl,
+                                $uid,
+                                $this->processTemplate( $calendar->title_template, Conversation::find( $conversation ), $calendar, $processedCustomFields ),
+                                $validatedData['body'],
+                                $start,
+                                $end,
+                                $isAllDay,
+                                $validatedData['location']
+                        );
+
+                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+                                Log::error( 'Error creating event', $response );
+
+                                return response()->json( [ 'error' => 'Error creating event' ], 500 );
+                        }
+
+                        $calendar->getExternalContent( true );
+                }
+
+                if ( $uid !== null ) {
+                        $conversation = Conversation::find( $conversation );
+                        if ( $conversation !== null ) {
+                                $action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
+                                $created_by_user_id = $userId;
+
+                                // Store the event UID for better permalink support
+                                $meta = [
+                                        'calendar_item_id' => $uid,
+                                        'calendar_id'      => $calendar->id,
+                                        'calendar_type'    => $calendar->type,
+                                        'start'            => ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) )->format( DATE_ATOM ),
+                                ];
+
+                                // For external calendars, also store the event UID
+                                if ( $calendar->type === 'caldav' || $calendar->type === 'ics' ) {
+                                        $meta['event_uid'] = $uid;
+                                }
+
+                                Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
+                                        'user_id'            => $conversation->user_id,
+                                        'created_by_user_id' => $created_by_user_id,
+                                        'action_type'        => $action_type,
+                                        'source_via'         => Thread::PERSON_USER,
+                                        'source_type'        => Thread::SOURCE_TYPE_WEB,
+                                        'meta'               => $meta,
+                                ] );
+                        }
+                }
+
+                return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
+        }
+
+        /**
+         * Get a calendar
+         *
+         * @param int $id
+         *
+         * @return JsonResponse
+         */
+        public function getCalendar( $id ) {
+                $calendar = Calendar::find( $id );
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                // Ensure we never return stale principals to the settings UI
+                $clean = $this->sanitizePermissions( $calendar->permissions );
+                if ( $clean !== ( $calendar->permissions ?? [] ) ) {
+                    $calendar->permissions = $clean;
+                    $calendar->save();
+                }
+
+                return response()->json( $calendar );
+        }
+
+        /**
+         * Get a single event by ID - optimized endpoint for permalinks
+         *
+         * @param string $eventId The event ID to retrieve
+         *
+         * @return JsonResponse
+         */
+        public function getEventById( string $eventId ): JsonResponse {
+                try {
+                        // Check if tables exist first
+                        if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
+                                return response()->json( [ 'error' => 'Calendar module not properly initialized' ], 500 );
+                        }
+
+                        $calendars = Calendar::all();
+
+                        foreach ( $calendars as $calendar ) {
+                                if ( $calendar->enabled === false ) {
+                                        continue;
+                                }
+
+                                $permissions = $calendar->permissionsForCurrentUser();
+                                if ( $permissions === null || ! $permissions['showInCalendar'] ) {
+                                        continue;
+                                }
+
+                                // For normal calendars, try to find the specific event by ID only
+                                if ( $calendar->type === 'normal' ) {
+                                        $event = CalendarItem::where( 'calendar_id', $calendar->id )
+                                                             ->where( 'id', $eventId )
+                                                             ->first();
+
+                                        if ( $event ) {
+                                                $eventData = json_decode( $event->toJson(), true );
+
+                                                // Ensure calendar ID is present
+                                                $eventData['calendarId'] = $calendar->id;
+
+                                                // Generate mapping for used custom fields
+                                                if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
+                                                        $eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                                                $calendar->custom_fields,
+                                                                $eventData['custom_fields']
+                                                        );
+                                                }
+
+                                                // Set default timezone
+                                                $defaultTimezone    = config( 'app.timezone' );
+                                                $eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )
+                                                        ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                                                $eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )
+                                                        ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+
+                                                // Ensure IDs are set
+                                                if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
+                                                        $eventData['id'] = $eventData['uid'];
+                                                }
+                                                if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
+                                                        $eventData['uid'] = $eventData['id'];
+                                                }
+                                                if ( empty( $eventData['title'] ) ) {
+                                                        $eventData['title'] = '';
+                                                }
+
+                                                return response()->json( $eventData );
+                                        }
+                                }
+
+                                // For external calendars, use optimized single event lookup
+                                if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
+                                        try {
+                                                $event = $calendar->findEventById( $eventId );
+
+                                                if ( $event ) {
+                                                        // Add calendar ID to the event data
+                                                        $event['calendarId']  = $calendar->id;
+                                                        $event['calendar_id'] = $calendar->id;
+
+                                                        // Generate mapping for used custom fields
+                                                        if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
+                                                                $event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+                                                                        $calendar->custom_fields,
+                                                                        $event['custom_fields']
+                                                                );
+                                                        }
+
+                                                        // Ensure timezone conversion is done
+                                                        $defaultTimezone = config( 'app.timezone' );
+                                                        $event['start']  = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )
+                                                                ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+                                                        $event['end']    = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )
+                                                                ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+
+                                                        return response()->json( $event );
+                                                }
+                                        } catch ( \Exception $e ) {
+                                                // Log and continue checking other calendars
+                                                \Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
+                                        }
+                                }
+                        }
+
+                        // Event not found in any calendar
+                        return response()->json( [ 'error' => 'Event not found' ], 404 );
+
+                } catch ( \Exception $e ) {
+                        \Log::error( 'Error in getEventById: ' . $e->getMessage() );
+
+                        return response()->json( [ 'error' => 'Failed to retrieve event' ], 500 );
+                }
+        }
+
+        /**
+         * Create an event from an attachment
+         *
+         * @param Request $request
+         *
+         * @return JsonResponse
+         * @throws Exception
+         */
+        public function createEventFromAttachment( Request $request ) {
+                try {
+                        $validatedData = $request->validate( [
+                                'attachmentId'   => 'required',
+                                'conversationId' => 'required',
+                                'calendarId'     => 'required',
+                        ] );
+                } catch ( Exception $e ) {
+                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
+                }
+
+                $calendar = Calendar::find( $validatedData['calendarId'] );
+                if ( ! $calendar ) {
+                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+                }
+
+                $userId = $this->requireAuthUserId();
+
+                $conversation = Conversation::find( $validatedData['conversationId'] );
+                if ( ! $conversation ) {
+                        return response()->json( [ 'error' => 'Conversation not found' ], 404 );
+                }
+
+                $attachment = Attachment::find( $validatedData['attachmentId'] );
+                if ( ! $attachment ) {
+                        return response()->json( [ 'error' => 'Attachment not found' ], 404 );
+                }
+                $file = $attachment->getLocalFilePath();
+
+                $ical = new ICal( $file );
+                /** @var Event[] $events */
+                $events = $ical->events();
+
+                $refetchCalendarIds = [];
+
+                //add conversation url to body
+                $conversationUrl = route( 'conversations.view', [ 'id' => $conversation->id ] );
+
+                foreach ( $events as $event ) {
+                        $start = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtstart_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
+                        if ( ! empty( $event->dtend ) ) {
+                                $end = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtend_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
+                        } else {
+                                if ( ! empty( $event->duration ) ) {
+                                        $end = $start->add( new DateInterval( $event->duration ) );
+                                } else {
+                                        $end = $start->add( new DateInterval( 'PT1H' ) );
+                                }
+                        }
+                        if ( $start->getTimestamp() === $end->getTimestamp() ) {
+                                $end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
+                        }
+                        $isAllDay = DateTimeRange::isAllDay( $start, $end );
+
+                        if ( $calendar->type === 'normal' ) {
+                                $calendarItem = new CalendarItem();
+
+                                $calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+                                $calendarItem->author_id   = $userId;
+                                $calendarItem->title       = $event->summary ?? 'Untitled Event';
+                                $calendarItem->start       = $start ?? Carbon::now();
+                                $calendarItem->end         = $end ?? Carbon::now()->addHour();
+                                $calendarItem->is_all_day  = $isAllDay ?? false;
+                                    $calendarItem->is_private  = false;
+                                    $calendarItem->is_read_only = false;
+                                    $calendarItem->state       = 'active';
+                                $calendarItem->location    = $event->location ?? '';
+                                $calendarItem->body        = $event->description ?? '';
+
+                                // Merge custom fields safely
+                                $customFields = $calendarItem->custom_fields;
+                                if ( ! is_array( $customFields ) ) {
+                                        $customFields = [];
+                                }
+
+                                $customFields['conversation_id'] = $conversation ? $conversation->id : null;
+                                $customFields['author_id']       = $userId;
+
+                                $calendarItem->custom_fields = $customFields;
+
+                                $calendarItem->save();
+                                $uid = $calendarItem->id;
+                        } else if ( $calendar->type === 'caldav' ) {
+                                $fullUrl      = $calendar->custom_fields['url'];
+                                $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+                                $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+                                $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+                                $uid = $event->uid ?? $this->GUID();
+
+                                $description = [
+                                        'body'          => empty( $event->description ) ? '-' : $event->description,
+                                        'custom_fields' => [
+                                                'conversation_id' => $conversation->id,
+                                                'author_id'       => $userId,
+                                        ],
+                                ];
+
+                                $response = $caldavClient->createEvent( $remainingUrl, $uid, $event->summary, $description, $start, $end, $isAllDay, $event->location );
+                                if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+                                        Log::error( 'Error creating event', $response );
+
+                                        return response()->json( [ 'error' => 'Error creating event', $response['body'], 'data' => [ $uid, $event->summary, $description, $start, $end, $event->location ] ], 500 );
+                                }
+                                $refetchCalendarIds[] = $calendar->id;
+                        }
+
+                        if ( $uid !== null ) {
+                                $action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
+                                $created_by_user_id = $userId;
+                                Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
+                                        'user_id'            => $conversation->user_id,
+                                        'created_by_user_id' => $created_by_user_id,
+                                        'action_type'        => $action_type,
+                                        'source_via'         => Thread::PERSON_USER,
+                                        'source_type'        => Thread::SOURCE_TYPE_WEB,
+                                        'meta'               => [
+                                                'calendar_item_id' => $uid,
+                                                'calendar_id'      => $calendar->id,
+                                                'start'            => $start->format( DATE_ATOM ),
+                                        ],
+                                ] );
+                        }
+                }
+
+                $refetchCalendarIds = array_values( array_unique( $refetchCalendarIds ) );
+                foreach ( $refetchCalendarIds as $refetchCalendarId ) {
+                        UpdateExternalCalendarJob::dispatch( $refetchCalendarId );
+                }
+
+                return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
+        }
 
 }

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -39,151 +39,90 @@ class LJPcCalendarModuleAPIController extends Controller {
 		 * may return Eloquent models or plain arrays. Normalize access.
 		 */
 		private function teamId( $team ): ?string {
-			if ( is_object( $team ) && isset( $team->id ) ) {
-				return (string) $team->id;
-			}
-			if ( is_array( $team ) && isset( $team['id'] ) ) {
-				return (string) $team['id'];
-			}
-			return null;
+				if ( is_object( $team ) && isset( $team->id ) ) {
+						return (string) $team->id;
+				}
+				if ( is_array( $team ) && isset( $team['id'] ) ) {
+						return (string) $team['id'];
+				}
+				return null;
 		}
 
 		private function teamLabel( $team ): string {
-			// Teams module historically uses "getFirstName()" (Team model extends User-ish API)
-			if ( is_object( $team ) ) {
-				if ( method_exists( $team, 'getFirstName' ) ) {
-					return (string) $team->getFirstName();
+				if ( is_object( $team ) ) {
+						if ( method_exists( $team, 'getFirstName' ) ) {
+								return (string) $team->getFirstName();
+						}
+						if ( isset( $team->name ) ) {
+								return (string) $team->name;
+						}
+						if ( isset( $team->title ) ) {
+								return (string) $team->title;
+						}
 				}
-				if ( isset( $team->name ) ) {
-					return (string) $team->name;
+				if ( is_array( $team ) ) {
+						return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
 				}
-				if ( isset( $team->title ) ) {
-					return (string) $team->title;
+				return '';
+		}
+
+		private function isTeamKey( string $key ): bool {
+				return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
+						|| str_starts_with( $key, 'team_' )
+						|| str_starts_with( $key, 'team:' );
+		}
+
+		private function normalizeTeamKey( string $key ): ?string {
+				if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
+						$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
+						return ctype_digit( $id ) ? $id : null;
 				}
-			}
-			if ( is_array( $team ) ) {
-				return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
-			}
-			return '';
+				if ( str_starts_with( $key, 'team_' ) ) {
+						$id = substr( $key, 5 );
+						return ctype_digit( $id ) ? $id : null;
+				}
+				if ( str_starts_with( $key, 'team:' ) ) {
+						$id = substr( $key, 5 );
+						return ctype_digit( $id ) ? $id : null;
+				}
+				return null;
 		}
-		/**
-		 * Build a map of all currently valid "principals" that can appear in calendar permissions.
-		 *
-		 * Principals are:
-		 *  - Active users (App\\User)
-		 *  - Teams (if the Teams module is installed)
-		 *
-		 * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
-		 */
-private function getValidPrincipals(): array {
-	$users = [];
-	$teams = [];
 
-	// Teams (optional module)
-	if ( class_exists( Teams::class ) ) {
-		// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
-		// Casting a Collection to array yields internal properties, not items, which would
-		// make us think there are no teams and prune all team permissions on save.
-		foreach ( Teams::getTeams( true ) as $team ) {
-			$teamId = $this->teamId( $team );
-			if ( $teamId === null ) {
-				continue;
-			}
-			$teams[$teamId] = true;
-		}
-	}
+		private function getValidPrincipals(): array {
+				$users = [];
+				$teams = [];
 
-	// Active users
-	$allUsers = User::where( 'status', User::STATUS_ACTIVE )
-	              ->remember( Helper::cacheTime() )
-	              ->get();
-	foreach ( $allUsers as $user ) {
-		$users[(string) $user->id] = true;
-	}
+				// Teams (optional module)
+				if ( class_exists( Teams::class ) ) {
+						// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
+						foreach ( Teams::getTeams( true ) as $team ) {
+								$teamId = $this->teamId( $team );
+								if ( $teamId === null ) {
+										continue;
+								}
+								$teams[ $teamId ] = true;
+						}
+				}
 
-	// Canonical permission keys: users are numeric strings; teams are namespaced.
-	$valid = $users;
-	foreach ( array_keys( $teams ) as $teamId ) {
-		$valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
-	}
+				// Active users
+				$allUsers = User::where( 'status', User::STATUS_ACTIVE )
+								->remember( Helper::cacheTime() )
+								->get();
+				foreach ( $allUsers as $user ) {
+						$users[ (string) $user->id ] = true;
+				}
 
-	return [
-		'users' => $users,
-		'teams' => $teams,
-		'valid' => $valid,
-	];
-}
+				// Canonical permission keys: users are numeric strings; teams are namespaced.
+				$valid = $users;
+				foreach ( array_keys( $teams ) as $teamId ) {
+						$valid[ self::TEAM_PRINCIPAL_PREFIX . $teamId ] = true;
+				}
 
-private function isTeamKey( string $key ): bool {
-	return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
-		|| str_starts_with( $key, 'team_' )
-		|| str_starts_with( $key, 'team:' );
-}
-
-private function normalizeTeamKey( string $key ): ?string {
-	if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
-		$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	if ( str_starts_with( $key, 'team_' ) ) {
-		$id = substr( $key, 5 );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	if ( str_starts_with( $key, 'team:' ) ) {
-		$id = substr( $key, 5 );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	return null;
-}
-
-
-		/**
-		 * Remove permission rows for principals (teams/users) that no longer exist.
-		 * This fixes stale permission keys after deleting a team (Teams module) or deactivating a user.
-		 *
-		 * @param array|null $permissions
-		 * @return array
-		 */
-		private function sanitizePermissions( $permissions ): array {
-			if ( ! is_array( $permissions ) ) {
-				return [];
-			}
-
-			$principals = $this->getValidPrincipals();
-			$valid      = $principals['valid'];
-			$clean = [];
-
-foreach ( $permissions as $id => $permission ) {
-	$key = (string) $id;
-
-	// Canonicalize team keys.
-	if ( $this->isTeamKey( $key ) ) {
-		$teamId = $this->normalizeTeamKey( $key );
-		if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
-			continue;
-		}
-		$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
-	} else if ( ctype_digit( $key ) ) {
-		// Backward compatibility: legacy numeric team IDs.
-		// Prefer users when ambiguous (user ID and team ID overlap).
-		if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
-			$key = self::TEAM_PRINCIPAL_PREFIX . $key;
-		}
-	}
-
-	if ( ! isset( $valid[$key] ) ) {
-		continue;
-	}
-
-	$clean[$key] = [
-					'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
-					'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
-					'createItems'     => (bool) ( $permission['createItems'] ?? false ),
-					'editItems'       => (bool) ( $permission['editItems'] ?? false ),
+				return [
+						'users' => $users,
+						'teams' => $teams,
+						'valid' => $valid,
 				];
-			}
-
-			return $clean;
 		}
 
 		/**
@@ -192,43 +131,81 @@ foreach ( $permissions as $id => $permission ) {
 		 * The UI may send permissions either as:
 		 *  - an associative array keyed by principal id (preferred), or
 		 *  - a numerically indexed list of objects with an 'id' field.
-		 *
-		 * Without normalization, numeric indexes (0,1,2,...) get treated as IDs and
-		 * sanitizePermissions() prunes everything as "invalid", making changes appear not to save.
-		 *
-		 * @param mixed $raw
-		 * @return array
 		 */
 		private function normalizePermissionsInput( $raw ): array {
-			if ( ! is_array( $raw ) ) {
-				return [];
-			}
-
-			// If it already looks like an associative map keyed by IDs, keep as-is.
-			$keys = array_keys( $raw );
-			$allNumeric = true;
-			foreach ( $keys as $k ) {
-				$kStr = (string) $k;
-				if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
-					$allNumeric = false;
-					break;
+				if ( ! is_array( $raw ) ) {
+						return [];
 				}
-			}
-			if ( ! $allNumeric ) {
-				return $raw;
-			}
 
-			// Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
-			$map = [];
-			foreach ( $raw as $row ) {
-				if ( is_array( $row ) && ! empty( $row['id'] ) ) {
-					$map[(string) $row['id']] = $row;
+				// If it already looks like an associative map keyed by IDs, keep as-is.
+				$keys       = array_keys( $raw );
+				$allNumeric = true;
+				foreach ( $keys as $k ) {
+						$kStr = (string) $k;
+						if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
+								$allNumeric = false;
+								break;
+						}
 				}
-			}
+				if ( ! $allNumeric ) {
+						return $raw;
+				}
 
-			return $map;
+				// Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
+				$map = [];
+				foreach ( $raw as $row ) {
+						if ( is_array( $row ) && ! empty( $row['id'] ) ) {
+								$map[ (string) $row['id'] ] = $row;
+						}
+				}
+
+				return $map;
 		}
 
+		/**
+		 * Remove permission rows for principals (teams/users) that no longer exist.
+		 */
+		private function sanitizePermissions( $permissions ): array {
+				if ( ! is_array( $permissions ) ) {
+						return [];
+				}
+
+				$principals = $this->getValidPrincipals();
+				$valid      = $principals['valid'];
+				$clean      = [];
+
+				foreach ( $permissions as $id => $permission ) {
+						$key = (string) $id;
+
+						// Canonicalize team keys.
+						if ( $this->isTeamKey( $key ) ) {
+								$teamId = $this->normalizeTeamKey( $key );
+								if ( $teamId === null || ! isset( $principals['teams'][ $teamId ] ) ) {
+										continue;
+								}
+								$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
+						} else if ( ctype_digit( $key ) ) {
+								// Backward compatibility: legacy numeric team IDs.
+								// Prefer users when ambiguous (user ID and team ID overlap).
+								if ( ! isset( $principals['users'][ $key ] ) && isset( $principals['teams'][ $key ] ) ) {
+										$key = self::TEAM_PRINCIPAL_PREFIX . $key;
+								}
+						}
+
+						if ( ! isset( $valid[ $key ] ) ) {
+								continue;
+						}
+
+						$clean[ $key ] = [
+								'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
+								'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
+								'createItems'     => (bool) ( $permission['createItems'] ?? false ),
+								'editItems'       => (bool) ( $permission['editItems'] ?? false ),
+						];
+				}
+
+				return $clean;
+		}
 
 		private function requireAuthUserId(): int {
 				$userId = auth()->id();
@@ -263,13 +240,13 @@ foreach ( $permissions as $id => $permission ) {
 				// Add team members to the response array
 				/** @var Team $team */
 				foreach ( $allTeams as $team ) {
-					$teamId = $this->teamId( $team );
-					if ( $teamId === null ) {
-						continue;
-					}
+						$teamId = $this->teamId( $team );
+						if ( $teamId === null ) {
+								continue;
+						}
 						$response['results'][] = [
-						'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
-						'text' => 'Team: ' . $this->teamLabel( $team ),
+								'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
+								'text' => 'Team: ' . $this->teamLabel( $team ),
 						];
 				}
 
@@ -293,13 +270,10 @@ foreach ( $permissions as $id => $permission ) {
 		public function getCalendars(): JsonResponse {
 				$calendars = Calendar::all();
 
-				// Prune stale permission keys (e.g. deleted Teams principals) to avoid broken UI and errors.
+				// Sanitize stale permission keys (e.g. deleted Teams principals) for the response only.
+				// Do not persist here: GET endpoints must stay read-only.
 				foreach ( $calendars as $calendar ) {
-					$clean = $this->sanitizePermissions( $calendar->permissions );
-					if ( $clean !== ( $calendar->permissions ?? [] ) ) {
-						$calendar->permissions = $clean;
-						$calendar->save();
-					}
+						$calendar->permissions = $this->sanitizePermissions( $calendar->permissions );
 				}
 
 				return response()->json( $calendars );
@@ -340,9 +314,9 @@ foreach ( $permissions as $id => $permission ) {
 								'refresh'  => $request->input( 'refresh' ),
 						] );
 				}
+
 				$permissions = [];
-				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
-				foreach ( $rawPermissions as $id => $permission ) {
+				foreach ( (array) $request->input( 'permissions', [] ) as $id => $permission ) {
 						$permissions[ $id ] = [
 								'showInDashboard' => $permission['showInDashboard'] ?? false,
 								'showInCalendar'  => $permission['showInCalendar'] ?? false,
@@ -427,9 +401,9 @@ foreach ( $permissions as $id => $permission ) {
 								'refresh'  => $request->input( 'refresh' ),
 						];
 				}
+
 				$permissions = [];
-				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
-				foreach ( $rawPermissions as $id => $permission ) {
+				foreach ( (array) $request->input( 'permissions', [] ) as $id => $permission ) {
 						$permissions[ $id ] = [
 								'showInDashboard' => $permission['showInDashboard'],
 								'showInCalendar'  => $permission['showInCalendar'],
@@ -942,12 +916,10 @@ foreach ( $permissions as $id => $permission ) {
 						$calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
 						$calendarItem->start       = $start ?? Carbon::now();
 						$calendarItem->end         = $end ?? Carbon::now()->addHour();
-						$calendarItem->is_all_day  = $isAllDay ?? false;
-									$calendarItem->is_private  = false;
-									$calendarItem->is_read_only = false;
-									$calendarItem->state       = 'active';
-						$calendarItem->is_private  = $validatedData['is_private'] ?? false;
-						$calendarItem->state       = $validatedData['state'] ?? 'active';
+						$calendarItem->is_all_day    = $isAllDay ?? false;
+						$calendarItem->is_private    = $validatedData['is_private'] ?? false;
+						$calendarItem->is_read_only  = false;
+						$calendarItem->state         = $validatedData['state'] ?? 'active';
 
 						$calendarItem->location      = $validatedData['location'] ?? '';
 						$calendarItem->body          = $validatedData['body'] ?? '';
@@ -1014,31 +986,6 @@ foreach ( $permissions as $id => $permission ) {
 				if ( ! $conversation ) {
 						return $template;
 				}
-
-				$result = str_replace( '{{title}}', $conversation->subject, $template );
-
-				// Get the field name mapping from calendar's custom fields configuration
-				$fieldMapping = [];
-
-				if ( ! empty( $calendar->custom_fields['fields'] ) ) {
-						foreach ( $calendar->custom_fields['fields'] as $field ) {
-								$fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
-						}
-				}
-
-				// Process custom fields using the mapping
-				foreach ( $customFields as $fieldId => $value ) {
-						if ( is_array( $value ) ) {
-								$value = implode( ', ', $value );
-						}
-
-						if ( isset( $fieldMapping[ $fieldId ] ) ) {
-								$fieldName = $fieldMapping[ $fieldId ];
-								$result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
-						}
-				}
-
-
 
 				$result = str_replace( '{{title}}', $conversation->subject, $template );
 
@@ -1138,12 +1085,10 @@ foreach ( $permissions as $id => $permission ) {
 						);
 						$calendarItem->start       = $start ?? Carbon::now();
 						$calendarItem->end         = $end ?? Carbon::now()->addHour();
-						$calendarItem->is_all_day  = $isAllDay ?? false;
-									$calendarItem->is_private  = false;
-									$calendarItem->is_read_only = false;
-									$calendarItem->state       = 'active';
-						$calendarItem->is_private  = false;
-						$calendarItem->state       = 'active';
+						$calendarItem->is_all_day    = $isAllDay ?? false;
+						$calendarItem->is_private    = false;
+						$calendarItem->is_read_only  = false;
+						$calendarItem->state         = 'active';
 						$calendarItem->location    = $validatedData['location'] ?? '';
 						$calendarItem->body        = $validatedData['body'] ?? '';
 
@@ -1266,12 +1211,8 @@ foreach ( $permissions as $id => $permission ) {
 						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
 				}
 
-				// Ensure we never return stale principals to the settings UI
-				$clean = $this->sanitizePermissions( $calendar->permissions );
-				if ( $clean !== ( $calendar->permissions ?? [] ) ) {
-					$calendar->permissions = $clean;
-					$calendar->save();
-				}
+				// Sanitize stale principals for the settings UI response only (do not persist in GET).
+				$calendar->permissions = $this->sanitizePermissions( $calendar->permissions );
 
 				return response()->json( $calendar );
 		}
@@ -1458,11 +1399,11 @@ foreach ( $permissions as $id => $permission ) {
 								$calendarItem->title       = $event->summary ?? 'Untitled Event';
 								$calendarItem->start       = $start ?? Carbon::now();
 								$calendarItem->end         = $end ?? Carbon::now()->addHour();
-								$calendarItem->is_all_day  = $isAllDay ?? false;
-									$calendarItem->is_private  = false;
-									$calendarItem->is_read_only = false;
-									$calendarItem->state       = 'active';
-								$calendarItem->location    = $event->location ?? '';
+								$calendarItem->is_all_day    = $isAllDay ?? false;
+								$calendarItem->is_private    = false;
+								$calendarItem->is_read_only  = false;
+								$calendarItem->state         = 'active';
+								$calendarItem->location      = $event->location ?? '';
 								$calendarItem->body        = $event->description ?? '';
 
 								// Merge custom fields safely

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -26,18 +26,9 @@ use Modules\LJPcCalendarModule\Jobs\UpdateExternalCalendarJob;
 use Modules\Teams\Providers\TeamsServiceProvider as Teams;
 
 class LJPcCalendarModuleAPIController extends Controller {
-		/**
-		 * Prefix used to namespace Team principals in permissions.
-		 *
-		 * Why: Teams and Users can share the same numeric ID space in different tables/modules.
-		 * Storing permissions keyed only by numbers can cause silent overwrites or pruning.
-		 */
+		// Namespace Team principals to avoid collisions with user IDs.
 		private const TEAM_PRINCIPAL_PREFIX = 't:';
 
-		/**
-		 * Teams module compatibility: depending on FreeScout/Teams versions, getTeams()
-		 * may return Eloquent models or plain arrays. Normalize access.
-		 */
 		private function teamId( $team ): ?string {
 				if ( is_object( $team ) && isset( $team->id ) ) {
 						return (string) $team->id;
@@ -125,13 +116,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 				];
 		}
 
-		/**
-		 * Normalize permissions payload from the UI.
-		 *
-		 * The UI may send permissions either as:
-		 *  - an associative array keyed by principal id (preferred), or
-		 *  - a numerically indexed list of objects with an 'id' field.
-		 */
+		// Normalize permissions payload from the UI (map or numeric-indexed list).
 		private function normalizePermissionsInput( $raw ): array {
 				if ( ! is_array( $raw ) ) {
 						return [];

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -75,67 +75,66 @@ class LJPcCalendarModuleAPIController extends Controller {
 		 *
 		 * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
 		 */
-private function getValidPrincipals(): array {
-	$users = [];
-	$teams = [];
+			private function getValidPrincipals(): array {
+				$users = [];
+				$teams = [];
 
-	// Teams (optional module)
-	if ( class_exists( Teams::class ) ) {
-		// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
-		// Casting a Collection to array yields internal properties, not items, which would
-		// make us think there are no teams and prune all team permissions on save.
-		foreach ( Teams::getTeams( true ) as $team ) {
-			$teamId = $this->teamId( $team );
-			if ( $teamId === null ) {
-				continue;
-			}
-			$teams[$teamId] = true;
+				// Teams (optional module)
+				if ( class_exists( Teams::class ) ) {
+					// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
+					// Casting a Collection to array yields internal properties, not items, which would
+					// make us think there are no teams and prune all team permissions on save.
+					foreach ( Teams::getTeams( true ) as $team ) {
+						$teamId = $this->teamId( $team );
+						if ( $teamId === null ) {
+							continue;
+						}
+						$teams[$teamId] = true;
+					}
+				}
+
+					// Active users
+					$allUsers = User::where( 'status', User::STATUS_ACTIVE )
+					->remember( Helper::cacheTime() )
+					->get();
+					foreach ( $allUsers as $user ) {
+						$users[(string) $user->id] = true;
+					}
+
+					// Canonical permission keys: users are numeric strings; teams are namespaced.
+					$valid = $users;
+					foreach ( array_keys( $teams ) as $teamId ) {
+						$valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
+					}
+
+					return [
+						'users' => $users,
+						'teams' => $teams,
+						'valid' => $valid,
+					];
 		}
-	}
 
-	// Active users
-	$allUsers = User::where( 'status', User::STATUS_ACTIVE )
-	              ->remember( Helper::cacheTime() )
-	              ->get();
-	foreach ( $allUsers as $user ) {
-		$users[(string) $user->id] = true;
-	}
+		private function isTeamKey( string $key ): bool {
+			return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
+			|| str_starts_with( $key, 'team_' )
+			|| str_starts_with( $key, 'team:' );
+		}
 
-	// Canonical permission keys: users are numeric strings; teams are namespaced.
-	$valid = $users;
-	foreach ( array_keys( $teams ) as $teamId ) {
-		$valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
-	}
-
-	return [
-		'users' => $users,
-		'teams' => $teams,
-		'valid' => $valid,
-	];
-}
-
-private function isTeamKey( string $key ): bool {
-	return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
-		|| str_starts_with( $key, 'team_' )
-		|| str_starts_with( $key, 'team:' );
-}
-
-private function normalizeTeamKey( string $key ): ?string {
-	if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
-		$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	if ( str_starts_with( $key, 'team_' ) ) {
-		$id = substr( $key, 5 );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	if ( str_starts_with( $key, 'team:' ) ) {
-		$id = substr( $key, 5 );
-		return ctype_digit( $id ) ? $id : null;
-	}
-	return null;
-}
-
+		private function normalizeTeamKey( string $key ): ?string {
+			if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
+				$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
+				return ctype_digit( $id ) ? $id : null;
+			}
+			if ( str_starts_with( $key, 'team_' ) ) {
+				$id = substr( $key, 5 );
+				return ctype_digit( $id ) ? $id : null;
+			}
+			if ( str_starts_with( $key, 'team:' ) ) {
+				$id = substr( $key, 5 );
+				return ctype_digit( $id ) ? $id : null;
+			}
+			return null;
+		}
 
 		/**
 		 * Remove permission rows for principals (teams/users) that no longer exist.
@@ -153,29 +152,29 @@ private function normalizeTeamKey( string $key ): ?string {
 			$valid      = $principals['valid'];
 			$clean = [];
 
-foreach ( $permissions as $id => $permission ) {
-	$key = (string) $id;
+			foreach ( $permissions as $id => $permission ) {
+				$key = (string) $id;
 
-	// Canonicalize team keys.
-	if ( $this->isTeamKey( $key ) ) {
-		$teamId = $this->normalizeTeamKey( $key );
-		if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
-			continue;
-		}
-		$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
-	} else if ( ctype_digit( $key ) ) {
-		// Backward compatibility: legacy numeric team IDs.
-		// Prefer users when ambiguous (user ID and team ID overlap).
-		if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
-			$key = self::TEAM_PRINCIPAL_PREFIX . $key;
-		}
-	}
+				// Canonicalize team keys.
+				if ( $this->isTeamKey( $key ) ) {
+					$teamId = $this->normalizeTeamKey( $key );
+					if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
+						continue;
+					}
+					$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
+				} else if ( ctype_digit( $key ) ) {
+					// Backward compatibility: legacy numeric team IDs.
+					// Prefer users when ambiguous (user ID and team ID overlap).
+					if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
+						$key = self::TEAM_PRINCIPAL_PREFIX . $key;
+					}
+				}
 
-	if ( ! isset( $valid[$key] ) ) {
-		continue;
-	}
+				if ( ! isset( $valid[$key] ) ) {
+					continue;
+				}
 
-	$clean[$key] = [
+				$clean[$key] = [
 					'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
 					'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
 					'createItems'     => (bool) ( $permission['createItems'] ?? false ),

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -29,6 +29,13 @@ class LJPcCalendarModuleAPIController extends Controller {
 		// Namespace Team principals to avoid collisions with user IDs.
 		private const TEAM_PRINCIPAL_PREFIX = 't:';
 
+		/**
+		 * Cache valid principals for the lifetime of the request.
+		 *
+		 * @var array|null
+		 */
+		private $validPrincipalsCache = null;
+
 		private function teamId( $team ): ?string {
 				if ( is_object( $team ) && isset( $team->id ) ) {
 						return (string) $team->id;
@@ -80,6 +87,10 @@ class LJPcCalendarModuleAPIController extends Controller {
 		}
 
 		private function getValidPrincipals(): array {
+				if ( $this->validPrincipalsCache !== null ) {
+						return $this->validPrincipalsCache;
+				}
+
 				$users = [];
 				$teams = [];
 
@@ -109,11 +120,13 @@ class LJPcCalendarModuleAPIController extends Controller {
 						$valid[ self::TEAM_PRINCIPAL_PREFIX . $teamId ] = true;
 				}
 
-				return [
+				$this->validPrincipalsCache = [
 						'users' => $users,
 						'teams' => $teams,
 						'valid' => $valid,
 				];
+
+				return $this->validPrincipalsCache;
 		}
 
 		// Normalize permissions payload from the UI (map or numeric-indexed list).
@@ -122,25 +135,24 @@ class LJPcCalendarModuleAPIController extends Controller {
 						return [];
 				}
 
-				// If it already looks like an associative map keyed by IDs, keep as-is.
-				$keys       = array_keys( $raw );
-				$allNumeric = true;
-				foreach ( $keys as $k ) {
-						$kStr = (string) $k;
-						if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
-								$allNumeric = false;
-								break;
+				// Associative maps keyed by principal IDs are already in the desired shape.
+				// Numeric user IDs become integer keys in PHP, so only treat the payload as a
+				// list when the keys are sequential 0..n.
+				$expectedIndex = 0;
+				foreach ( array_keys( $raw ) as $key ) {
+						if ( $key !== $expectedIndex ) {
+								return $raw;
 						}
-				}
-				if ( ! $allNumeric ) {
-						return $raw;
+						$expectedIndex++;
 				}
 
-				// Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
+				// Convert a numeric list of rows like: [ {id: 123, ...}, ... ] into an ID-keyed map.
 				$map = [];
 				foreach ( $raw as $row ) {
-						if ( is_array( $row ) && ! empty( $row['id'] ) ) {
+						if ( is_array( $row ) && array_key_exists( 'id', $row ) && $row['id'] !== null && $row['id'] !== '' ) {
 								$map[ (string) $row['id'] ] = $row;
+						} else if ( is_object( $row ) && isset( $row->id ) && $row->id !== null && $row->id !== '' ) {
+								$map[ (string) $row->id ] = (array) $row;
 						}
 				}
 
@@ -301,7 +313,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 				}
 
 				$permissions = [];
-				foreach ( (array) $request->input( 'permissions', [] ) as $id => $permission ) {
+				foreach ( $this->normalizePermissionsInput( $request->input( 'permissions', [] ) ) as $id => $permission ) {
 						$permissions[ $id ] = [
 								'showInDashboard' => $permission['showInDashboard'] ?? false,
 								'showInCalendar'  => $permission['showInCalendar'] ?? false,
@@ -388,7 +400,7 @@ class LJPcCalendarModuleAPIController extends Controller {
 				}
 
 				$permissions = [];
-				foreach ( (array) $request->input( 'permissions', [] ) as $id => $permission ) {
+				foreach ( $this->normalizePermissionsInput( $request->input( 'permissions', [] ) ) as $id => $permission ) {
 						$permissions[ $id ] = [
 								'showInDashboard' => $permission['showInDashboard'],
 								'showInCalendar'  => $permission['showInCalendar'],

--- a/Http/Controllers/LJPcCalendarModuleAPIController.php
+++ b/Http/Controllers/LJPcCalendarModuleAPIController.php
@@ -26,1506 +26,1507 @@ use Modules\LJPcCalendarModule\Jobs\UpdateExternalCalendarJob;
 use Modules\Teams\Providers\TeamsServiceProvider as Teams;
 
 class LJPcCalendarModuleAPIController extends Controller {
-        /**
-         * Prefix used to namespace Team principals in permissions.
-         *
-         * Why: Teams and Users can share the same numeric ID space in different tables/modules.
-         * Storing permissions keyed only by numbers can cause silent overwrites or pruning.
-         */
-        private const TEAM_PRINCIPAL_PREFIX = 't:';
-
-        /**
-         * Teams module compatibility: depending on FreeScout/Teams versions, getTeams()
-         * may return Eloquent models or plain arrays. Normalize access.
-         */
-        private function teamId( $team ): ?string {
-            if ( is_object( $team ) && isset( $team->id ) ) {
-                return (string) $team->id;
-            }
-            if ( is_array( $team ) && isset( $team['id'] ) ) {
-                return (string) $team['id'];
-            }
-            return null;
-        }
-
-        private function teamLabel( $team ): string {
-            // Teams module historically uses "getFirstName()" (Team model extends User-ish API)
-            if ( is_object( $team ) ) {
-                if ( method_exists( $team, 'getFirstName' ) ) {
-                    return (string) $team->getFirstName();
-                }
-                if ( isset( $team->name ) ) {
-                    return (string) $team->name;
-                }
-                if ( isset( $team->title ) ) {
-                    return (string) $team->title;
-                }
-            }
-            if ( is_array( $team ) ) {
-                return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
-            }
-            return '';
-        }
-        /**
-         * Build a map of all currently valid "principals" that can appear in calendar permissions.
-         *
-         * Principals are:
-         *  - Active users (App\\User)
-         *  - Teams (if the Teams module is installed)
-         *
-         * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
-         */
-            private function getValidPrincipals(): array {
-                $users = [];
-                $teams = [];
-
-                // Teams (optional module)
-                if ( class_exists( Teams::class ) ) {
-                    // Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
-                    // Casting a Collection to array yields internal properties, not items, which would
-                    // make us think there are no teams and prune all team permissions on save.
-                    foreach ( Teams::getTeams( true ) as $team ) {
-                        $teamId = $this->teamId( $team );
-                        if ( $teamId === null ) {
-                            continue;
-                        }
-                        $teams[$teamId] = true;
-                    }
-                }
-
-                    // Active users
-                    $allUsers = User::where( 'status', User::STATUS_ACTIVE )
-                    ->remember( Helper::cacheTime() )
-                    ->get();
-                    foreach ( $allUsers as $user ) {
-                        $users[(string) $user->id] = true;
-                    }
-
-                    // Canonical permission keys: users are numeric strings; teams are namespaced.
-                    $valid = $users;
-                    foreach ( array_keys( $teams ) as $teamId ) {
-                        $valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
-                    }
-
-                    return [
-                        'users' => $users,
-                        'teams' => $teams,
-                        'valid' => $valid,
-                    ];
-        }
-
-        private function isTeamKey( string $key ): bool {
-            return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
-            || str_starts_with( $key, 'team_' )
-            || str_starts_with( $key, 'team:' );
-        }
-
-        private function normalizeTeamKey( string $key ): ?string {
-            if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
-                $id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
-                return ctype_digit( $id ) ? $id : null;
-            }
-            if ( str_starts_with( $key, 'team_' ) ) {
-                $id = substr( $key, 5 );
-                return ctype_digit( $id ) ? $id : null;
-            }
-            if ( str_starts_with( $key, 'team:' ) ) {
-                $id = substr( $key, 5 );
-                return ctype_digit( $id ) ? $id : null;
-            }
-            return null;
-        }
-
-        /**
-         * Remove permission rows for principals (teams/users) that no longer exist.
-         * This fixes stale permission keys after deleting a team (Teams module) or deactivating a user.
-         *
-         * @param array|null $permissions
-         * @return array
-         */
-        private function sanitizePermissions( $permissions ): array {
-            if ( ! is_array( $permissions ) ) {
-                return [];
-            }
-
-            $principals = $this->getValidPrincipals();
-            $valid      = $principals['valid'];
-            $clean = [];
-
-            foreach ( $permissions as $id => $permission ) {
-                $key = (string) $id;
-
-                // Canonicalize team keys.
-                if ( $this->isTeamKey( $key ) ) {
-                    $teamId = $this->normalizeTeamKey( $key );
-                    if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
-                        continue;
-                    }
-                    $key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
-                } else if ( ctype_digit( $key ) ) {
-                    // Backward compatibility: legacy numeric team IDs.
-                    // Prefer users when ambiguous (user ID and team ID overlap).
-                    if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
-                        $key = self::TEAM_PRINCIPAL_PREFIX . $key;
-                    }
-                }
-
-                if ( ! isset( $valid[$key] ) ) {
-                    continue;
-                }
-
-                $clean[$key] = [
-                    'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
-                    'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
-                    'createItems'     => (bool) ( $permission['createItems'] ?? false ),
-                    'editItems'       => (bool) ( $permission['editItems'] ?? false ),
-                ];
-            }
-
-            return $clean;
-        }
-
-        /**
-         * Normalize permissions payload from the UI.
-         *
-         * The UI may send permissions either as:
-         *  - an associative array keyed by principal id (preferred), or
-         *  - a numerically indexed list of objects with an 'id' field.
-         *
-         * Without normalization, numeric indexes (0,1,2,...) get treated as IDs and
-         * sanitizePermissions() prunes everything as "invalid", making changes appear not to save.
-         *
-         * @param mixed $raw
-         * @return array
-         */
-        private function normalizePermissionsInput( $raw ): array {
-            if ( ! is_array( $raw ) ) {
-                return [];
-            }
-
-            // If it already looks like an associative map keyed by IDs, keep as-is.
-            $keys = array_keys( $raw );
-            $allNumeric = true;
-            foreach ( $keys as $k ) {
-                $kStr = (string) $k;
-                if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
-                    $allNumeric = false;
-                    break;
-                }
-            }
-            if ( ! $allNumeric ) {
-                return $raw;
-            }
-
-            // Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
-            $map = [];
-            foreach ( $raw as $row ) {
-                if ( is_array( $row ) && ! empty( $row['id'] ) ) {
-                    $map[(string) $row['id']] = $row;
-                }
-            }
-
-            return $map;
-        }
-
-
-        private function requireAuthUserId(): int {
-                $userId = auth()->id();
-                if ( ! $userId ) {
-                        abort( 401, 'Unauthenticated' );
-                }
-
-                return (int) $userId;
-        }
-
-        /**
-         * Get users for the settings
-         *
-         * @return JsonResponse A JSON response containing an array of user objects
-         */
-        public function getUsers(): JsonResponse {
-                $response = [
-                        'results' => [],
-                ];
-
-                // Get all teams
-                $allTeams = [];
-                if ( class_exists( Teams::class ) ) {
-                        $allTeams = Teams::getTeams( true );
-                }
-
-                // Get all users that are active
-                $allUsers = User::where( 'status', User::STATUS_ACTIVE )
-                                ->remember( Helper::cacheTime() )
-                                ->get();
-
-                // Add team members to the response array
-                /** @var Team $team */
-                foreach ( $allTeams as $team ) {
-                    $teamId = $this->teamId( $team );
-                    if ( $teamId === null ) {
-                        continue;
-                    }
-                        $response['results'][] = [
-                        'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
-                        'text' => 'Team: ' . $this->teamLabel( $team ),
-                        ];
-                }
-
-                // Add users to the response array
-                /** @var User $user */
-                foreach ( $allUsers as $user ) {
-                        $response['results'][] = [
-                                'id'   => (string) $user->id,
-                                'text' => $user->getFullName(),
-                        ];
-                }
-
-                return response()->json( $response );
-        }
-
-        /**
-         * Get calendars for the settings
-         *
-         * @return JsonResponse A JSON response containing an array of calendar objects
-         */
-        public function getCalendars(): JsonResponse {
-                $calendars = Calendar::all();
-
-                // Prune stale permission keys (e.g. deleted Teams principals) to avoid broken UI and errors.
-                foreach ( $calendars as $calendar ) {
-                    $clean = $this->sanitizePermissions( $calendar->permissions );
-                    if ( $clean !== ( $calendar->permissions ?? [] ) ) {
-                        $calendar->permissions = $clean;
-                        $calendar->save();
-                    }
-                }
-
-                return response()->json( $calendars );
-        }
-
-        /**
-         * Update a calendar
-         *
-         * @param int $id The ID of the calendar to update
-         * @param Request $request The request object
-         *
-         * @return JsonResponse A JSON response containing the updated calendar object
-         */
-        public function updateCalendar( int $id, Request $request ) {
-                $calendar = Calendar::find( $id );
-
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                $calendar->name           = $request->input( 'name' );
-                $calendar->color          = $request->input( 'color' );
-                $calendar->title_template = $request->input( 'title_template' );
-
-                $customFields            = $request->input( 'custom_fields', [] );
-                $calendar->custom_fields = $this->validateCustomFields( $customFields );
-
-                if ( $calendar->type === 'ics' ) {
-                        $calendar->custom_fields = array_merge( $calendar->custom_fields, [
-                                'url'     => $request->input( 'url' ),
-                                'refresh' => $request->input( 'refresh' ),
-                        ] );
-                } else if ( $calendar->type === 'caldav' ) {
-                        $calendar->custom_fields = array_merge( $calendar->custom_fields, [
-                                'url'      => $request->input( 'url' ),
-                                'username' => $request->input( 'username' ),
-                                'password' => $request->input( 'password' ),
-                                'refresh'  => $request->input( 'refresh' ),
-                        ] );
-                }
-                $permissions = [];
-                $rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
-                foreach ( $rawPermissions as $id => $permission ) {
-                        $permissions[ $id ] = [
-                                'showInDashboard' => $permission['showInDashboard'] ?? false,
-                                'showInCalendar'  => $permission['showInCalendar'] ?? false,
-                                'createItems'     => $permission['createItems'] ?? false,
-                                'editItems'       => $permission['editItems'] ?? false,
-                        ];
-                }
-                $calendar->permissions = $this->sanitizePermissions( $permissions );
-
-                $calendar->save();
-
-                return response()->json( $calendar );
-        }
-
-        /**
-         * Validate and sanitize custom fields
-         *
-         * @param array $customFields The custom fields to validate
-         *
-         * @return array The validated and sanitized custom fields
-         */
-        private function validateCustomFields( array $customFields ): array {
-                if ( empty( $customFields['fields'] ) || ! is_array( $customFields['fields'] ) ) {
-                        return [ 'fields' => [] ];
-                }
-                $validatedFields = [];
-
-                foreach ( $customFields['fields'] as $field ) {
-                        $validatedField = [
-                                'id'       => $field['id'] ?? null,
-                                'name'     => strip_tags( $field['name'] ?? '' ),
-                                'type'     => in_array( $field['type'], [ 'text', 'number', 'dropdown', 'boolean', 'multiselect', 'date', 'email', 'source' ] ) ? $field['type'] : 'text',
-                                'required' => (bool) ( $field['required'] ?? false ),
-                        ];
-
-                        if ( $validatedField['type'] === 'source' ) {
-                                $validatedField['required'] = false;
-                        }
-
-                        if ( in_array( $field['type'], [ 'dropdown', 'multiselect' ] ) ) {
-                                $options = $field['options'] ?? [];
-                                if ( ! is_array( $options ) ) {
-                                        $options = explode( ',', $options );
-                                }
-                                $validatedField['options'] = array_map( 'trim', array_map( fn( $opt ) => strip_tags( (string) $opt ), $options ) );
-                        }
-
-                        $validatedFields[] = $validatedField;
-                }
-
-                return [ 'fields' => $validatedFields ];
-        }
-
-        /**
-         * Create a new calendar
-         *
-         * @param Request $request The request object
-         *
-         * @return JsonResponse A JSON response containing the created calendar object
-         */
-        public function addCalendar( Request $request ) {
-                $calendar = new Calendar();
-
-                $calendar->name           = strip_tags( $request->input( 'name' ) ?? 'Default Calendar' );
-                $calendar->color          = $request->input( 'color' );
-                $calendar->type           = $request->input( 'type' );
-                $calendar->title_template = $request->input( 'title_template' );
-
-                $customFields            = $request->input( 'custom_fields', [] );
-                $calendar->custom_fields = $this->validateCustomFields( $customFields );
-
-                if ( $calendar->type === 'ics' ) {
-                        $calendar->custom_fields = [
-                                'url'     => $request->input( 'url' ),
-                                'refresh' => $request->input( 'refresh' ),
-                        ];
-                } else if ( $calendar->type === 'caldav' ) {
-                        $calendar->custom_fields = [
-                                'url'      => $request->input( 'url' ),
-                                'username' => $request->input( 'username' ),
-                                'password' => $request->input( 'password' ),
-                                'refresh'  => $request->input( 'refresh' ),
-                        ];
-                }
-                $permissions = [];
-                $rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
-                foreach ( $rawPermissions as $id => $permission ) {
-                        $permissions[ $id ] = [
-                                'showInDashboard' => $permission['showInDashboard'],
-                                'showInCalendar'  => $permission['showInCalendar'],
-                                'createItems'     => $permission['createItems'] ?? false,
-                                'editItems'       => $permission['editItems'] ?? false,
-                        ];
-                }
-                $calendar->permissions = $this->sanitizePermissions( $permissions );
-
-                $calendar->save();
-
-                return response()->json( $calendar );
-        }
-
-        /**
-         * Delete a calendar
-         *
-         * @param int $id The ID of the calendar to delete
-         *
-         * @return JsonResponse A JSON response indicating the deletion result
-         * @throws Exception
-         */
-        public function deleteCalendar( int $id ): JsonResponse {
-                $calendar = Calendar::find( $id );
-
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
-                        //remove temporary ics file
-                        $filename = $calendar->getTemporaryFile();
-                        if ( file_exists( $filename ) ) {
-                                unlink( $filename );
-                        }
-                } else {
-                        //remove all calendar items for this calendar
-                        CalendarItem::where( 'calendar_id', $calendar->id )->delete();
-                }
-
-                $calendar->delete();
-
-                return response()->json( [ 'ok' => true, 'message' => 'Calendar deleted successfully' ] );
-        }
-
-
-        /**
-         * Get events
-         *
-         * This method handles both date range queries and specific event ID lookups.
-         * For event ID lookups on external calendars, it uses an optimized approach
-         * that avoids loading unnecessary date ranges, improving performance for large calendars.
-         *
-         * @param Request $request The request containing either date range (start/end) or eventId
-         *
-         * @return JsonResponse Array of events matching the criteria
-         * @throws Exception
-         */
-        public function getEvents( Request $request ) {
-                // Special case: If looking for a specific event by ID
-                $eventId = $request->input( 'eventId' );
-                if ( $eventId ) {
-                        try {
-                                // Check if tables exist first
-                                if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
-                                        return response()->json( [] );
-                                }
-
-                                $events    = [];
-                                $calendars = Calendar::all();
-
-                                foreach ( $calendars as $calendar ) {
-                                        if ( $calendar->enabled === false ) {
-                                                continue;
-                                        }
-                                        $permissions = $calendar->permissionsForCurrentUser();
-                                        if ( $permissions === null ) {
-                                                continue;
-                                        }
-                                        if ( $permissions['showInCalendar'] !== true ) {
-                                                continue;
-                                        }
-
-                                        // For normal calendars, try to find the specific event
-                                        if ( $calendar->type === 'normal' ) {
-                                                $event = CalendarItem::where( 'uid', $eventId )
-                                                                     ->orWhere( 'id', $eventId )
-                                                                     ->where( 'calendar_id', $calendar->id )
-                                                                     ->first();
-
-                                                if ( $event ) {
-                                                        // Found the event, return it
-                                                        $eventData = json_decode( $event->toJson(), true );
-
-                                                        // Generate mapping for used custom fields
-                                                        if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
-                                                                $eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                                                        $calendar->custom_fields,
-                                                                        $eventData['custom_fields']
-                                                                );
-                                                        }
-
-                                                        // Set default timezone
-                                                        $defaultTimezone    = config( 'app.timezone' );
-                                                        $eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                                                        $eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-
-                                                        if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
-                                                                $eventData['id'] = $eventData['uid'];
-                                                        }
-                                                        if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
-                                                                $eventData['uid'] = $eventData['id'];
-                                                        }
-                                                        if ( empty( $eventData['title'] ) ) {
-                                                                $eventData['title'] = '';
-                                                        }
-
-                                                        $events[] = $eventData;
-                                                        break;
-                                                }
-                                        }
-
-                                        // For external calendars, use optimized single event lookup
-                                        if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
-                                                try {
-                                                        // Use the new optimized method for finding a single event
-                                                        $event = $calendar->findEventById( $eventId );
-
-                                                        if ( $event ) {
-                                                                // Found the event, prepare it for return
-                                                                if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
-                                                                        $event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                                                                $calendar->custom_fields,
-                                                                                $event['custom_fields']
-                                                                        );
-                                                                }
-                                                                $events[] = $event;
-                                                                break;
-                                                        }
-                                                } catch ( \Exception $e ) {
-                                                        // Log and continue - we don't want a single calendar to break the entire request
-                                                        \Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
-                                                }
-                                        }
-                                }
-
-                                // Restore timezones
-                                $defaultTimezone = config( 'app.timezone' );
-                                foreach ( $events as &$event ) {
-                                        $event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                                        $event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                                }
-                                unset( $event );
-
-                                return response()->json( $events );
-                        } catch ( \Exception $e ) {
-                                // Log the error but return a valid response
-                                \Log::error( 'Error in getEvents by ID: ' . $e->getMessage() );
-
-                                return response()->json( [] );
-                        }
-                }
-
-                try {
-                        // Regular date range query
-                        $request->validate( [
-                                'start' => 'required|date',
-                                'end'   => 'required|date',
-                        ] );
-
-                        // Check if tables exist first
-                        if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
-                                return response()->json( [] );
-                        }
-
-                        $defaultTimezone = config( 'app.timezone' );
-
-                        $start = ( new DateTimeImmutable( $request->input( 'start' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                        $end   = ( new DateTimeImmutable( $request->input( 'end' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-
-                        $calendars = Calendar::all();
-                        $events    = [];
-
-                        foreach ( $calendars as $calendar ) {
-                                if ( $calendar->enabled === false ) {
-                                        continue;
-                                }
-                                $permissions = $calendar->permissionsForCurrentUser();
-                                if ( $permissions === null ) {
-                                        continue;
-                                }
-                                if ( $permissions['showInCalendar'] !== true ) {
-                                        continue;
-                                }
-
-                                try {
-                                        $calendarEvents = $calendar->events( $start, $end );
-                                        foreach ( $calendarEvents as $event ) {
-                                                // Generate mapping for used custom fields
-                                                if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
-                                                        $event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                                                $calendar->custom_fields,
-                                                                $event['custom_fields']
-                                                        );
-                                                }
-                                                $events[] = $event;
-                                        }
-                                } catch ( \Exception $e ) {
-                                        // Log and continue - we don't want a single calendar to break the entire request
-                                        \Log::error( 'Error fetching events from calendar ' . $calendar->id . ': ' . $e->getMessage() );
-                                }
-                        }
-
-                        /**
-                         * Restore timezones
-                         */
-                        foreach ( $events as &$event ) {
-                                if ( empty( $event['id'] ) && ! empty( $event['uid'] ) ) {
-                                        $event['id'] = $event['uid'];
-                                }
-                                if ( empty( $event['uid'] ) && ! empty( $event['id'] ) ) {
-                                        $event['uid'] = $event['id'];
-                                }
-                                if ( empty( $event['title'] ) ) {
-                                        $event['title'] = '';
-                                }
-
-                                $event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                                $event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                        }
-                        unset( $event );
-
-                        return response()->json( $events );
-                } catch ( \Exception $e ) {
-                        // Log the error but return a valid response
-                        \Log::error( 'Error in getEvents date range: ' . $e->getMessage() );
-
-                        return response()->json( [] );
-                }
-        }
-
-        /**
-         * Update an event
-         *
-         * @param Request $request
-         *
-         * @return JsonResponse
-         * @throws Exception
-         */
-        public function updateEvent( Request $request ) {
-                try {
-                        $validatedData = $request->validate( [
-                                'uid'          => 'required',
-                                'title'        => 'required',
-                                'start'        => 'required|date',
-                                'end'          => 'required|date|after:start',
-                                'location'     => 'nullable',
-                                'body'         => 'nullable',
-                                'calendarId'   => 'required',
-                                'customFields' => 'nullable',
-                        ] );
-                } catch ( Exception $e ) {
-                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
-                }
-
-                $calendar = Calendar::find( $validatedData['calendarId'] );
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                $customFieldsData      = $validatedData['customFields'] ?? [];
-                $customFields          = $calendar->custom_fields['fields'] ?? [];
-                $processedCustomFields = [];
-
-                foreach ( $customFields as $field ) {
-                        $fieldId = 'custom_field_' . $field['id'];
-                        if ( isset( $customFieldsData[ $fieldId ] ) ) {
-                                $processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
-                        } else if ( $field['required'] ) {
-                                return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
-                        }
-                }
-
-                if ( $calendar->type === 'normal' ) {
-                        $calendarItem = CalendarItem::where( 'id', $validatedData['uid'] )->first();
-                        if ( ! $calendarItem ) {
-                                return response()->json( [ 'error' => 'Event not found' ], 404 );
-                        }
-
-                        $calendarItem->title    = $validatedData['title'];
-                        $calendarItem->start    = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                        $calendarItem->end      = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                        $calendarItem->location = $validatedData['location'];
-                        $calendarItem->body     = $validatedData['body'] ?? '';
-                        if ( ! is_array( $calendarItem->custom_fields ) ) {
-                                $calendarItem->custom_fields = [];
-                        }
-                        $calendarItem->custom_fields = array_merge( $calendarItem->custom_fields, $processedCustomFields );
-
-                        $calendarItem->save();
-                } else if ( $calendar->type === 'caldav' ) {
-                        $fullUrl = $calendar->custom_fields['url'] ?? '';
-
-                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-                                return response()->json( [
-                                        'status'  => 'error',
-                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
-                                ], 422 );
-                        }
-
-                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-                        $start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                        $end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-
-                        if ( isset( $customFieldsData['author_id'] ) ) {
-                                $processedCustomFields['author_id'] = $customFieldsData['author_id'];
-                        }
-                        if ( isset( $customFieldsData['conversation_id'] ) ) {
-                                $processedCustomFields['conversation_id'] = $customFieldsData['conversation_id'];
-                        }
-
-                        if ( count( $processedCustomFields ) > 0 ) {
-                                if ( ! is_array( $validatedData['body'] ) ) {
-                                        $validatedData['body'] = [ 'body' => $validatedData['body'] ];
-                                }
-
-                                if ( ! isset( $validatedData['body']['custom_fields'] ) || ! is_array( $validatedData['body']['custom_fields'] ) ) {
-                                        $validatedData['body']['custom_fields'] = [];
-                                }
-
-                                $validatedData['body']['custom_fields'] = array_merge(
-                                        $validatedData['body']['custom_fields'],
-                                        $processedCustomFields
-                                );
-
-                                // Add mapping for used custom fields
-                                $validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                        $calendar->custom_fields,
-                                        $processedCustomFields
-                                );
-                        }
-
-                        $response = $caldavClient->updateEvent(
-                                $remainingUrl,
-                                $validatedData['uid'],
-                                $validatedData['title'],
-                                $validatedData['body'],
-                                $start,
-                                $end,
-                                $validatedData['location']
-                        );
-
-                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-                                Log::error( 'Error updating event', $response );
-
-                                return response()->json( [ 'error' => 'Error updating event' ], 500 );
-                        }
-
-                        $calendar->getExternalContent( true );
-                }
-
-                return response()->json( [ 'ok' => true, 'message' => 'Event updated successfully' ] );
-        }
-
-        /**
-         * Generate a GUID
-         * @return string
-         */
-        private function GUID() {
-                if ( function_exists( 'com_create_guid' ) === true ) {
-                        return trim( com_create_guid(), '{}' );
-                }
-
-                return sprintf( '%04X%04X-%04X-%04X-%04X-%04X%04X%04X', mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 16384, 20479 ), mt_rand( 32768, 49151 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ) );
-        }
-
-        /**
-         * Delete an event
-         *
-         * @param Request $request
-         *
-         * @return JsonResponse
-         * @throws Exception
-         */
-        public function deleteEvent( Request $request ) {
-                $eventId    = $request->input( 'id' );
-                $calendarId = $request->input( 'calendarId' );
-
-                $calendar = Calendar::find( $calendarId );
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                if ( $calendar->type === 'normal' ) {
-                        $calendarItem = CalendarItem::where( 'id', $eventId )->first();
-                        if ( ! $calendarItem ) {
-                                return response()->json( [ 'error' => 'Event not found' ], 404 );
-                        }
-                        $calendarItem->delete();
-                } else if ( $calendar->type === 'caldav' ) {
-                        $fullUrl = $calendar->custom_fields['url'] ?? '';
-
-                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-                                return response()->json( [
-                                        'status'  => 'error',
-                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
-                                ], 422 );
-                        }
-
-                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-                        $response = $caldavClient->deleteEvent( $remainingUrl, $eventId );
-                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-                                Log::error( 'Error deleting event', $response );
-
-                                return response()->json( [ 'error' => 'Error deleting event' ], 500 );
-                        }
-                        $calendar->getExternalContent( true );
-                }
-
-                return response()->json( [ 'ok' => true, 'message' => 'Event deleted successfully' ] );
-        }
-
-        /**
-         * Helper function to generate custom field mapping
-         *
-         * @param array $customFields Array of all possible custom fields
-         * @param array $usedCustomFields Array of used custom field values
-         *
-         * @return array Mapping of used custom field IDs to their names
-         */
-        private function generateCustomFieldMapping( array $customFields, array $usedCustomFields ): array {
-                $mapping = [];
-                $fields  = $customFields['fields'] ?? [];
-
-                foreach ( $fields as $field ) {
-                        $fieldId = 'custom_field_' . $field['id'];
-                        // Only include fields that are actually used in the item
-                        if ( isset( $usedCustomFields[ $fieldId ] ) ) {
-                                $mapping[ $fieldId ] = $field['name'];
-                        }
-                }
-
-                return $mapping;
-        }
-
-        /**
-         * Create an event
-         *
-         * @param Request $request
-         *
-         * @return JsonResponse
-         * @throws Exception
-         */
-        public function createEvent( Request $request ) {
-                try {
-                        $validatedData = $request->validate( [
-                                'title'        => 'required',
-                                'start'        => 'required|date',
-                                'end'          => 'required|date',
-                                'location'     => 'nullable',
-                                'body'         => 'nullable',
-                                'calendarId'   => 'required',
-                                'customFields' => 'nullable',
-                        ] );
-                } catch ( Exception $e ) {
-                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
-                }
-
-                $calendar = Calendar::find( $validatedData['calendarId'] );
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                $userId = $this->requireAuthUserId();
-
-                $customFieldsData      = $validatedData['customFields'] ?? [];
-                $customFields          = $calendar->custom_fields['fields'] ?? [];
-                $processedCustomFields = [
-                        'author_id' => $userId,
-                ];
-
-                foreach ( $customFields as $field ) {
-                        $fieldId = 'custom_field_' . $field['id'];
-                        if ( isset( $customFieldsData[ $fieldId ] ) ) {
-                                $processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
-                        } else if ( $field['required'] ) {
-                                return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
-                        }
-                }
-
-                $start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                $end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                if ( $start->getTimestamp() === $end->getTimestamp() ) {
-                        $end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
-                }
-
-                $isAllDay = DateTimeRange::isAllDay( $start, $end );
-
-                if ( $calendar->type === 'normal' ) {
-                        $calendarItem = new CalendarItem();
-
-                        $calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-                        $calendarItem->author_id   = $userId;
-                        $calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
-                        $calendarItem->start       = $start ?? Carbon::now();
-                        $calendarItem->end         = $end ?? Carbon::now()->addHour();
-                        $calendarItem->is_all_day  = $isAllDay ?? false;
-                                    $calendarItem->is_private  = false;
-                                    $calendarItem->is_read_only = false;
-                                    $calendarItem->state       = 'active';
-                        $calendarItem->is_private  = $validatedData['is_private'] ?? false;
-                        $calendarItem->state       = $validatedData['state'] ?? 'active';
-
-                        $calendarItem->location      = $validatedData['location'] ?? '';
-                        $calendarItem->body          = $validatedData['body'] ?? '';
-                        $calendarItem->custom_fields = $processedCustomFields ?? [];
-
-                        $calendarItem->save();
-                } else if ( $calendar->type === 'caldav' ) {
-                        $fullUrl = $calendar->custom_fields['url'] ?? '';
-
-                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-                                return response()->json( [
-                                        'status'  => 'error',
-                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
-                                ], 422 );
-                        }
-
-                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-                        $uid = $this->GUID();
-
-                        if ( ! is_array( $validatedData['body'] ) ) {
-                                $validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
-                        }
-
-                        $validatedData['body']['custom_fields'] = $processedCustomFields;
-
-                        // Add mapping for used custom fields
-                        $validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                $calendar->custom_fields,
-                                $processedCustomFields
-                        );
-
-                        $response = $caldavClient->createEvent(
-                                $remainingUrl,
-                                $uid,
-                                $validatedData['title'],
-                                $validatedData['body'],
-                                $start,
-                                $end,
-                                $isAllDay,
-                                $validatedData['location']
-                        );
-
-                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-                                Log::error( 'Error creating event', $response );
-
-                                return response()->json( [ 'error' => 'Error creating event' ], 500 );
-                        }
-
-                        $calendar->getExternalContent( true );
-                }
-
-                return response()->json( [ 'ok' => true, 'message' => 'Event created successfully' ] );
-        }
-
-        private function processTemplate(
-                string        $template,
-                ?Conversation $conversation,
-                Calendar      $calendar,
-                array         $customFields = []
-        ): string {
-                if ( ! $conversation ) {
-                        return $template;
-                }
-
-                $result = str_replace( '{{title}}', $conversation->subject, $template );
-
-                // Get the field name mapping from calendar's custom fields configuration
-                $fieldMapping = [];
-
-                if ( ! empty( $calendar->custom_fields['fields'] ) ) {
-                        foreach ( $calendar->custom_fields['fields'] as $field ) {
-                                $fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
-                        }
-                }
-
-                // Process custom fields using the mapping
-                foreach ( $customFields as $fieldId => $value ) {
-                        if ( is_array( $value ) ) {
-                                $value = implode( ', ', $value );
-                        }
-
-                        if ( isset( $fieldMapping[ $fieldId ] ) ) {
-                                $fieldName = $fieldMapping[ $fieldId ];
-                                $result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
-                        }
-                }
-
-
-
-                $result = str_replace( '{{title}}', $conversation->subject, $template );
-
-                // Get the field name mapping from calendar's custom fields configuration
-                $fieldMapping = [];
-
-                if ( ! empty( $calendar->custom_fields['fields'] ) ) {
-                        foreach ( $calendar->custom_fields['fields'] as $field ) {
-                                $fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
-                        }
-                }
-
-                // Process custom fields using the mapping
-                foreach ( $customFields as $fieldId => $value ) {
-                        if ( is_array( $value ) ) {
-                                $value = implode( ', ', $value );
-                        }
-
-                        if ( isset( $fieldMapping[ $fieldId ] ) ) {
-                                $fieldName = $fieldMapping[ $fieldId ];
-                                $result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
-                        }
-                }
-
-                return $result;
-        }
-
-
-        /**
-         * Create an event from a conversation
-         *
-         * @param int $conversation
-         * @param Request $request
-         *
-         * @return JsonResponse
-         * @throws Exception
-         */
-        public function createEventFromConversation( int $conversation, Request $request ) {
-                try {
-                        $validatedData = $request->validate( [
-                                'title'        => 'required|nullable',
-                                'start'        => 'required|date',
-                                'end'          => 'required|date|after:start',
-                                'location'     => 'nullable',
-                                'body'         => 'nullable',
-                                'calendarId'   => 'required',
-                                'customFields' => 'nullable',
-                        ] );
-                } catch ( Exception $e ) {
-                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
-                }
-
-                $calendar = Calendar::find( $validatedData['calendarId'] );
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                $userId = $this->requireAuthUserId();
-
-                $conversationObj = Conversation::find( $conversation );
-
-                $start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                $end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
-                if ( $start->getTimestamp() === $end->getTimestamp() ) {
-                        $end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
-                }
-                $isAllDay = DateTimeRange::isAllDay( $start, $end );
-
-                $customFieldsData      = $validatedData['customFields'] ?? [];
-                $customFields          = $calendar->custom_fields['fields'] ?? [];
-                $processedCustomFields = [];
-
-                foreach ( $customFields as $field ) {
-                        $fieldId = 'custom_field_' . $field['id'];
-                        if ( isset( $customFieldsData[ $fieldId ] ) ) {
-                                $processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
-                        } else if ( $field['required'] ) {
-                                return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
-                        }
-                }
-
-                if ( empty( $calendar->title_template ) ) {
-                        $calendar->title_template = $request->input( 'title' );
-                }
-
-                $uid = null;
-                if ( $calendar->type === 'normal' ) {
-                        $calendarItem = new CalendarItem();
-
-                        $calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-                        $calendarItem->author_id   = $userId;
-                        $calendarItem->title       = $this->processTemplate(
-                                $calendar->title_template,
-                                $conversationObj,
-                                $calendar,
-                                $processedCustomFields ?? []
-                        );
-                        $calendarItem->start       = $start ?? Carbon::now();
-                        $calendarItem->end         = $end ?? Carbon::now()->addHour();
-                        $calendarItem->is_all_day  = $isAllDay ?? false;
-                                    $calendarItem->is_private  = false;
-                                    $calendarItem->is_read_only = false;
-                                    $calendarItem->state       = 'active';
-                        $calendarItem->is_private  = false;
-                        $calendarItem->state       = 'active';
-                        $calendarItem->location    = $validatedData['location'] ?? '';
-                        $calendarItem->body        = $validatedData['body'] ?? '';
-
-                        // Merge all custom fields safely
-                        $customFields = $calendarItem->custom_fields;
-                        if ( ! is_array( $customFields ) ) {
-                                $customFields = [];
-                        }
-
-                        $mergedCustomFields = array_merge(
-                                $customFields,
-                                [
-                                        'conversation_id' => $conversation,
-                                        'author_id'       => $userId,
-                                ],
-                                $processedCustomFields ?? []
-                        );
-
-                        $calendarItem->custom_fields = $mergedCustomFields;
-
-                        $calendarItem->save();
-                        $uid = $calendarItem->id;
-                } else if ( $calendar->type === 'caldav' ) {
-                        $fullUrl = $calendar->custom_fields['url'] ?? '';
-
-                        if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
-                                return response()->json( [
-                                        'status'  => 'error',
-                                        'message' => 'CalDAV calendar is not properly configured (missing URL).',
-                                ], 422 );
-                        }
-
-                        $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-                        $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-                        $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-                        $uid = $this->GUID();
-
-                        if ( ! is_array( $validatedData['body'] ) ) {
-                                $validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
-                        }
-
-                        // Merge all custom fields
-                        $mergedCustomFields = array_merge( [
-                                'conversation_id' => $conversation,
-                                'author_id'       => $userId,
-                        ], $processedCustomFields );
-
-                        $validatedData['body']['custom_fields'] = $mergedCustomFields;
-
-                        // Add mapping for used custom fields
-                        $validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                $calendar->custom_fields,
-                                $mergedCustomFields
-                        );
-
-                        $response = $caldavClient->createEvent(
-                                $remainingUrl,
-                                $uid,
-                                $this->processTemplate( $calendar->title_template, Conversation::find( $conversation ), $calendar, $processedCustomFields ),
-                                $validatedData['body'],
-                                $start,
-                                $end,
-                                $isAllDay,
-                                $validatedData['location']
-                        );
-
-                        if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-                                Log::error( 'Error creating event', $response );
-
-                                return response()->json( [ 'error' => 'Error creating event' ], 500 );
-                        }
-
-                        $calendar->getExternalContent( true );
-                }
-
-                if ( $uid !== null ) {
-                        $conversation = Conversation::find( $conversation );
-                        if ( $conversation !== null ) {
-                                $action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
-                                $created_by_user_id = $userId;
-
-                                // Store the event UID for better permalink support
-                                $meta = [
-                                        'calendar_item_id' => $uid,
-                                        'calendar_id'      => $calendar->id,
-                                        'calendar_type'    => $calendar->type,
-                                        'start'            => ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) )->format( DATE_ATOM ),
-                                ];
-
-                                // For external calendars, also store the event UID
-                                if ( $calendar->type === 'caldav' || $calendar->type === 'ics' ) {
-                                        $meta['event_uid'] = $uid;
-                                }
-
-                                Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
-                                        'user_id'            => $conversation->user_id,
-                                        'created_by_user_id' => $created_by_user_id,
-                                        'action_type'        => $action_type,
-                                        'source_via'         => Thread::PERSON_USER,
-                                        'source_type'        => Thread::SOURCE_TYPE_WEB,
-                                        'meta'               => $meta,
-                                ] );
-                        }
-                }
-
-                return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
-        }
-
-        /**
-         * Get a calendar
-         *
-         * @param int $id
-         *
-         * @return JsonResponse
-         */
-        public function getCalendar( $id ) {
-                $calendar = Calendar::find( $id );
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                // Ensure we never return stale principals to the settings UI
-                $clean = $this->sanitizePermissions( $calendar->permissions );
-                if ( $clean !== ( $calendar->permissions ?? [] ) ) {
-                    $calendar->permissions = $clean;
-                    $calendar->save();
-                }
-
-                return response()->json( $calendar );
-        }
-
-        /**
-         * Get a single event by ID - optimized endpoint for permalinks
-         *
-         * @param string $eventId The event ID to retrieve
-         *
-         * @return JsonResponse
-         */
-        public function getEventById( string $eventId ): JsonResponse {
-                try {
-                        // Check if tables exist first
-                        if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
-                                return response()->json( [ 'error' => 'Calendar module not properly initialized' ], 500 );
-                        }
-
-                        $calendars = Calendar::all();
-
-                        foreach ( $calendars as $calendar ) {
-                                if ( $calendar->enabled === false ) {
-                                        continue;
-                                }
-
-                                $permissions = $calendar->permissionsForCurrentUser();
-                                if ( $permissions === null || ! $permissions['showInCalendar'] ) {
-                                        continue;
-                                }
-
-                                // For normal calendars, try to find the specific event by ID only
-                                if ( $calendar->type === 'normal' ) {
-                                        $event = CalendarItem::where( 'calendar_id', $calendar->id )
-                                                             ->where( 'id', $eventId )
-                                                             ->first();
-
-                                        if ( $event ) {
-                                                $eventData = json_decode( $event->toJson(), true );
-
-                                                // Ensure calendar ID is present
-                                                $eventData['calendarId'] = $calendar->id;
-
-                                                // Generate mapping for used custom fields
-                                                if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
-                                                        $eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                                                $calendar->custom_fields,
-                                                                $eventData['custom_fields']
-                                                        );
-                                                }
-
-                                                // Set default timezone
-                                                $defaultTimezone    = config( 'app.timezone' );
-                                                $eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )
-                                                        ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                                                $eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )
-                                                        ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-
-                                                // Ensure IDs are set
-                                                if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
-                                                        $eventData['id'] = $eventData['uid'];
-                                                }
-                                                if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
-                                                        $eventData['uid'] = $eventData['id'];
-                                                }
-                                                if ( empty( $eventData['title'] ) ) {
-                                                        $eventData['title'] = '';
-                                                }
-
-                                                return response()->json( $eventData );
-                                        }
-                                }
-
-                                // For external calendars, use optimized single event lookup
-                                if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
-                                        try {
-                                                $event = $calendar->findEventById( $eventId );
-
-                                                if ( $event ) {
-                                                        // Add calendar ID to the event data
-                                                        $event['calendarId']  = $calendar->id;
-                                                        $event['calendar_id'] = $calendar->id;
-
-                                                        // Generate mapping for used custom fields
-                                                        if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
-                                                                $event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
-                                                                        $calendar->custom_fields,
-                                                                        $event['custom_fields']
-                                                                );
-                                                        }
-
-                                                        // Ensure timezone conversion is done
-                                                        $defaultTimezone = config( 'app.timezone' );
-                                                        $event['start']  = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )
-                                                                ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-                                                        $event['end']    = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )
-                                                                ->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
-
-                                                        return response()->json( $event );
-                                                }
-                                        } catch ( \Exception $e ) {
-                                                // Log and continue checking other calendars
-                                                \Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
-                                        }
-                                }
-                        }
-
-                        // Event not found in any calendar
-                        return response()->json( [ 'error' => 'Event not found' ], 404 );
-
-                } catch ( \Exception $e ) {
-                        \Log::error( 'Error in getEventById: ' . $e->getMessage() );
-
-                        return response()->json( [ 'error' => 'Failed to retrieve event' ], 500 );
-                }
-        }
-
-        /**
-         * Create an event from an attachment
-         *
-         * @param Request $request
-         *
-         * @return JsonResponse
-         * @throws Exception
-         */
-        public function createEventFromAttachment( Request $request ) {
-                try {
-                        $validatedData = $request->validate( [
-                                'attachmentId'   => 'required',
-                                'conversationId' => 'required',
-                                'calendarId'     => 'required',
-                        ] );
-                } catch ( Exception $e ) {
-                        return response()->json( [ 'error' => $e->getMessage() ], 400 );
-                }
-
-                $calendar = Calendar::find( $validatedData['calendarId'] );
-                if ( ! $calendar ) {
-                        return response()->json( [ 'error' => 'Calendar not found' ], 404 );
-                }
-
-                $userId = $this->requireAuthUserId();
-
-                $conversation = Conversation::find( $validatedData['conversationId'] );
-                if ( ! $conversation ) {
-                        return response()->json( [ 'error' => 'Conversation not found' ], 404 );
-                }
-
-                $attachment = Attachment::find( $validatedData['attachmentId'] );
-                if ( ! $attachment ) {
-                        return response()->json( [ 'error' => 'Attachment not found' ], 404 );
-                }
-                $file = $attachment->getLocalFilePath();
-
-                $ical = new ICal( $file );
-                /** @var Event[] $events */
-                $events = $ical->events();
-
-                $refetchCalendarIds = [];
-
-                //add conversation url to body
-                $conversationUrl = route( 'conversations.view', [ 'id' => $conversation->id ] );
-
-                foreach ( $events as $event ) {
-                        $start = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtstart_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
-                        if ( ! empty( $event->dtend ) ) {
-                                $end = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtend_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
-                        } else {
-                                if ( ! empty( $event->duration ) ) {
-                                        $end = $start->add( new DateInterval( $event->duration ) );
-                                } else {
-                                        $end = $start->add( new DateInterval( 'PT1H' ) );
-                                }
-                        }
-                        if ( $start->getTimestamp() === $end->getTimestamp() ) {
-                                $end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
-                        }
-                        $isAllDay = DateTimeRange::isAllDay( $start, $end );
-
-                        if ( $calendar->type === 'normal' ) {
-                                $calendarItem = new CalendarItem();
-
-                                $calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
-                                $calendarItem->author_id   = $userId;
-                                $calendarItem->title       = $event->summary ?? 'Untitled Event';
-                                $calendarItem->start       = $start ?? Carbon::now();
-                                $calendarItem->end         = $end ?? Carbon::now()->addHour();
-                                $calendarItem->is_all_day  = $isAllDay ?? false;
-                                    $calendarItem->is_private  = false;
-                                    $calendarItem->is_read_only = false;
-                                    $calendarItem->state       = 'active';
-                                $calendarItem->location    = $event->location ?? '';
-                                $calendarItem->body        = $event->description ?? '';
-
-                                // Merge custom fields safely
-                                $customFields = $calendarItem->custom_fields;
-                                if ( ! is_array( $customFields ) ) {
-                                        $customFields = [];
-                                }
-
-                                $customFields['conversation_id'] = $conversation ? $conversation->id : null;
-                                $customFields['author_id']       = $userId;
-
-                                $calendarItem->custom_fields = $customFields;
-
-                                $calendarItem->save();
-                                $uid = $calendarItem->id;
-                        } else if ( $calendar->type === 'caldav' ) {
-                                $fullUrl      = $calendar->custom_fields['url'];
-                                $baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
-                                $remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
-                                $caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
-
-                                $uid = $event->uid ?? $this->GUID();
-
-                                $description = [
-                                        'body'          => empty( $event->description ) ? '-' : $event->description,
-                                        'custom_fields' => [
-                                                'conversation_id' => $conversation->id,
-                                                'author_id'       => $userId,
-                                        ],
-                                ];
-
-                                $response = $caldavClient->createEvent( $remainingUrl, $uid, $event->summary, $description, $start, $end, $isAllDay, $event->location );
-                                if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
-                                        Log::error( 'Error creating event', $response );
-
-                                        return response()->json( [ 'error' => 'Error creating event', $response['body'], 'data' => [ $uid, $event->summary, $description, $start, $end, $event->location ] ], 500 );
-                                }
-                                $refetchCalendarIds[] = $calendar->id;
-                        }
-
-                        if ( $uid !== null ) {
-                                $action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
-                                $created_by_user_id = $userId;
-                                Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
-                                        'user_id'            => $conversation->user_id,
-                                        'created_by_user_id' => $created_by_user_id,
-                                        'action_type'        => $action_type,
-                                        'source_via'         => Thread::PERSON_USER,
-                                        'source_type'        => Thread::SOURCE_TYPE_WEB,
-                                        'meta'               => [
-                                                'calendar_item_id' => $uid,
-                                                'calendar_id'      => $calendar->id,
-                                                'start'            => $start->format( DATE_ATOM ),
-                                        ],
-                                ] );
-                        }
-                }
-
-                $refetchCalendarIds = array_values( array_unique( $refetchCalendarIds ) );
-                foreach ( $refetchCalendarIds as $refetchCalendarId ) {
-                        UpdateExternalCalendarJob::dispatch( $refetchCalendarId );
-                }
-
-                return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
-        }
+		/**
+		 * Prefix used to namespace Team principals in permissions.
+		 *
+		 * Why: Teams and Users can share the same numeric ID space in different tables/modules.
+		 * Storing permissions keyed only by numbers can cause silent overwrites or pruning.
+		 */
+		private const TEAM_PRINCIPAL_PREFIX = 't:';
+
+		/**
+		 * Teams module compatibility: depending on FreeScout/Teams versions, getTeams()
+		 * may return Eloquent models or plain arrays. Normalize access.
+		 */
+		private function teamId( $team ): ?string {
+			if ( is_object( $team ) && isset( $team->id ) ) {
+				return (string) $team->id;
+			}
+			if ( is_array( $team ) && isset( $team['id'] ) ) {
+				return (string) $team['id'];
+			}
+			return null;
+		}
+
+		private function teamLabel( $team ): string {
+			// Teams module historically uses "getFirstName()" (Team model extends User-ish API)
+			if ( is_object( $team ) ) {
+				if ( method_exists( $team, 'getFirstName' ) ) {
+					return (string) $team->getFirstName();
+				}
+				if ( isset( $team->name ) ) {
+					return (string) $team->name;
+				}
+				if ( isset( $team->title ) ) {
+					return (string) $team->title;
+				}
+			}
+			if ( is_array( $team ) ) {
+				return (string) ( $team['name'] ?? $team['title'] ?? $team['first_name'] ?? '' );
+			}
+			return '';
+		}
+		/**
+		 * Build a map of all currently valid "principals" that can appear in calendar permissions.
+		 *
+		 * Principals are:
+		 *  - Active users (App\\User)
+		 *  - Teams (if the Teams module is installed)
+		 *
+		 * @return array<string, bool> Keys are IDs (string), value always true for fast lookup
+		 */
+private function getValidPrincipals(): array {
+	$users = [];
+	$teams = [];
+
+	// Teams (optional module)
+	if ( class_exists( Teams::class ) ) {
+		// Do NOT cast to array: Teams::getTeams(true) may return a Collection/Iterable.
+		// Casting a Collection to array yields internal properties, not items, which would
+		// make us think there are no teams and prune all team permissions on save.
+		foreach ( Teams::getTeams( true ) as $team ) {
+			$teamId = $this->teamId( $team );
+			if ( $teamId === null ) {
+				continue;
+			}
+			$teams[$teamId] = true;
+		}
+	}
+
+	// Active users
+	$allUsers = User::where( 'status', User::STATUS_ACTIVE )
+	              ->remember( Helper::cacheTime() )
+	              ->get();
+	foreach ( $allUsers as $user ) {
+		$users[(string) $user->id] = true;
+	}
+
+	// Canonical permission keys: users are numeric strings; teams are namespaced.
+	$valid = $users;
+	foreach ( array_keys( $teams ) as $teamId ) {
+		$valid[self::TEAM_PRINCIPAL_PREFIX . $teamId] = true;
+	}
+
+	return [
+		'users' => $users,
+		'teams' => $teams,
+		'valid' => $valid,
+	];
+}
+
+private function isTeamKey( string $key ): bool {
+	return str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX )
+		|| str_starts_with( $key, 'team_' )
+		|| str_starts_with( $key, 'team:' );
+}
+
+private function normalizeTeamKey( string $key ): ?string {
+	if ( str_starts_with( $key, self::TEAM_PRINCIPAL_PREFIX ) ) {
+		$id = substr( $key, strlen( self::TEAM_PRINCIPAL_PREFIX ) );
+		return ctype_digit( $id ) ? $id : null;
+	}
+	if ( str_starts_with( $key, 'team_' ) ) {
+		$id = substr( $key, 5 );
+		return ctype_digit( $id ) ? $id : null;
+	}
+	if ( str_starts_with( $key, 'team:' ) ) {
+		$id = substr( $key, 5 );
+		return ctype_digit( $id ) ? $id : null;
+	}
+	return null;
+}
+
+
+		/**
+		 * Remove permission rows for principals (teams/users) that no longer exist.
+		 * This fixes stale permission keys after deleting a team (Teams module) or deactivating a user.
+		 *
+		 * @param array|null $permissions
+		 * @return array
+		 */
+		private function sanitizePermissions( $permissions ): array {
+			if ( ! is_array( $permissions ) ) {
+				return [];
+			}
+
+			$principals = $this->getValidPrincipals();
+			$valid      = $principals['valid'];
+			$clean = [];
+
+foreach ( $permissions as $id => $permission ) {
+	$key = (string) $id;
+
+	// Canonicalize team keys.
+	if ( $this->isTeamKey( $key ) ) {
+		$teamId = $this->normalizeTeamKey( $key );
+		if ( $teamId === null || ! isset( $principals['teams'][$teamId] ) ) {
+			continue;
+		}
+		$key = self::TEAM_PRINCIPAL_PREFIX . $teamId;
+	} else if ( ctype_digit( $key ) ) {
+		// Backward compatibility: legacy numeric team IDs.
+		// Prefer users when ambiguous (user ID and team ID overlap).
+		if ( ! isset( $principals['users'][$key] ) && isset( $principals['teams'][$key] ) ) {
+			$key = self::TEAM_PRINCIPAL_PREFIX . $key;
+		}
+	}
+
+	if ( ! isset( $valid[$key] ) ) {
+		continue;
+	}
+
+	$clean[$key] = [
+					'showInDashboard' => (bool) ( $permission['showInDashboard'] ?? false ),
+					'showInCalendar'  => (bool) ( $permission['showInCalendar'] ?? false ),
+					'createItems'     => (bool) ( $permission['createItems'] ?? false ),
+					'editItems'       => (bool) ( $permission['editItems'] ?? false ),
+				];
+			}
+
+			return $clean;
+		}
+
+		/**
+		 * Normalize permissions payload from the UI.
+		 *
+		 * The UI may send permissions either as:
+		 *  - an associative array keyed by principal id (preferred), or
+		 *  - a numerically indexed list of objects with an 'id' field.
+		 *
+		 * Without normalization, numeric indexes (0,1,2,...) get treated as IDs and
+		 * sanitizePermissions() prunes everything as "invalid", making changes appear not to save.
+		 *
+		 * @param mixed $raw
+		 * @return array
+		 */
+		private function normalizePermissionsInput( $raw ): array {
+			if ( ! is_array( $raw ) ) {
+				return [];
+			}
+
+			// If it already looks like an associative map keyed by IDs, keep as-is.
+			$keys = array_keys( $raw );
+			$allNumeric = true;
+			foreach ( $keys as $k ) {
+				$kStr = (string) $k;
+				if ( $kStr === '' || ! ctype_digit( $kStr ) ) {
+					$allNumeric = false;
+					break;
+				}
+			}
+			if ( ! $allNumeric ) {
+				return $raw;
+			}
+
+			// Otherwise assume it's a list of rows like: [ {id: 123, ...}, ... ].
+			$map = [];
+			foreach ( $raw as $row ) {
+				if ( is_array( $row ) && ! empty( $row['id'] ) ) {
+					$map[(string) $row['id']] = $row;
+				}
+			}
+
+			return $map;
+		}
+
+
+		private function requireAuthUserId(): int {
+				$userId = auth()->id();
+				if ( ! $userId ) {
+						abort( 401, 'Unauthenticated' );
+				}
+
+				return (int) $userId;
+		}
+
+		/**
+		 * Get users for the settings
+		 *
+		 * @return JsonResponse A JSON response containing an array of user objects
+		 */
+		public function getUsers(): JsonResponse {
+				$response = [
+						'results' => [],
+				];
+
+				// Get all teams
+				$allTeams = [];
+				if ( class_exists( Teams::class ) ) {
+						$allTeams = Teams::getTeams( true );
+				}
+
+				// Get all users that are active
+				$allUsers = User::where( 'status', User::STATUS_ACTIVE )
+				                ->remember( Helper::cacheTime() )
+				                ->get();
+
+				// Add team members to the response array
+				/** @var Team $team */
+				foreach ( $allTeams as $team ) {
+					$teamId = $this->teamId( $team );
+					if ( $teamId === null ) {
+						continue;
+					}
+						$response['results'][] = [
+						'id'   => self::TEAM_PRINCIPAL_PREFIX . $teamId,
+						'text' => 'Team: ' . $this->teamLabel( $team ),
+						];
+				}
+
+				// Add users to the response array
+				/** @var User $user */
+				foreach ( $allUsers as $user ) {
+						$response['results'][] = [
+								'id'   => (string) $user->id,
+								'text' => $user->getFullName(),
+						];
+				}
+
+				return response()->json( $response );
+		}
+
+		/**
+		 * Get calendars for the settings
+		 *
+		 * @return JsonResponse A JSON response containing an array of calendar objects
+		 */
+		public function getCalendars(): JsonResponse {
+				$calendars = Calendar::all();
+
+				// Prune stale permission keys (e.g. deleted Teams principals) to avoid broken UI and errors.
+				foreach ( $calendars as $calendar ) {
+					$clean = $this->sanitizePermissions( $calendar->permissions );
+					if ( $clean !== ( $calendar->permissions ?? [] ) ) {
+						$calendar->permissions = $clean;
+						$calendar->save();
+					}
+				}
+
+				return response()->json( $calendars );
+		}
+
+		/**
+		 * Update a calendar
+		 *
+		 * @param int $id The ID of the calendar to update
+		 * @param Request $request The request object
+		 *
+		 * @return JsonResponse A JSON response containing the updated calendar object
+		 */
+		public function updateCalendar( int $id, Request $request ) {
+				$calendar = Calendar::find( $id );
+
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				$calendar->name           = $request->input( 'name' );
+				$calendar->color          = $request->input( 'color' );
+				$calendar->title_template = $request->input( 'title_template' );
+
+				$customFields            = $request->input( 'custom_fields', [] );
+				$calendar->custom_fields = $this->validateCustomFields( $customFields );
+
+				if ( $calendar->type === 'ics' ) {
+						$calendar->custom_fields = array_merge( $calendar->custom_fields, [
+								'url'     => $request->input( 'url' ),
+								'refresh' => $request->input( 'refresh' ),
+						] );
+				} else if ( $calendar->type === 'caldav' ) {
+						$calendar->custom_fields = array_merge( $calendar->custom_fields, [
+								'url'      => $request->input( 'url' ),
+								'username' => $request->input( 'username' ),
+								'password' => $request->input( 'password' ),
+								'refresh'  => $request->input( 'refresh' ),
+						] );
+				}
+				$permissions = [];
+				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
+				foreach ( $rawPermissions as $id => $permission ) {
+						$permissions[ $id ] = [
+								'showInDashboard' => $permission['showInDashboard'] ?? false,
+								'showInCalendar'  => $permission['showInCalendar'] ?? false,
+								'createItems'     => $permission['createItems'] ?? false,
+								'editItems'       => $permission['editItems'] ?? false,
+						];
+				}
+				$calendar->permissions = $this->sanitizePermissions( $permissions );
+
+				$calendar->save();
+
+				return response()->json( $calendar );
+		}
+
+		/**
+		 * Validate and sanitize custom fields
+		 *
+		 * @param array $customFields The custom fields to validate
+		 *
+		 * @return array The validated and sanitized custom fields
+		 */
+		private function validateCustomFields( array $customFields ): array {
+				if ( empty( $customFields['fields'] ) || ! is_array( $customFields['fields'] ) ) {
+						return [ 'fields' => [] ];
+				}
+				$validatedFields = [];
+
+				foreach ( $customFields['fields'] as $field ) {
+						$validatedField = [
+								'id'       => $field['id'] ?? null,
+								'name'     => strip_tags( $field['name'] ?? '' ),
+								'type'     => in_array( $field['type'], [ 'text', 'number', 'dropdown', 'boolean', 'multiselect', 'date', 'email', 'source' ] ) ? $field['type'] : 'text',
+								'required' => (bool) ( $field['required'] ?? false ),
+						];
+
+						if ( $validatedField['type'] === 'source' ) {
+								$validatedField['required'] = false;
+						}
+
+						if ( in_array( $field['type'], [ 'dropdown', 'multiselect' ] ) ) {
+								$options = $field['options'] ?? [];
+								if ( ! is_array( $options ) ) {
+										$options = explode( ',', $options );
+								}
+								$validatedField['options'] = array_map( 'trim', array_map( fn( $opt ) => strip_tags( (string) $opt ), $options ) );
+						}
+
+						$validatedFields[] = $validatedField;
+				}
+
+				return [ 'fields' => $validatedFields ];
+		}
+
+		/**
+		 * Create a new calendar
+		 *
+		 * @param Request $request The request object
+		 *
+		 * @return JsonResponse A JSON response containing the created calendar object
+		 */
+		public function addCalendar( Request $request ) {
+				$calendar = new Calendar();
+
+				$calendar->name           = strip_tags( $request->input( 'name' ) ?? 'Default Calendar' );
+				$calendar->color          = $request->input( 'color' );
+				$calendar->type           = $request->input( 'type' );
+				$calendar->title_template = $request->input( 'title_template' );
+
+				$customFields            = $request->input( 'custom_fields', [] );
+				$calendar->custom_fields = $this->validateCustomFields( $customFields );
+
+				if ( $calendar->type === 'ics' ) {
+						$calendar->custom_fields = [
+								'url'     => $request->input( 'url' ),
+								'refresh' => $request->input( 'refresh' ),
+						];
+				} else if ( $calendar->type === 'caldav' ) {
+						$calendar->custom_fields = [
+								'url'      => $request->input( 'url' ),
+								'username' => $request->input( 'username' ),
+								'password' => $request->input( 'password' ),
+								'refresh'  => $request->input( 'refresh' ),
+						];
+				}
+				$permissions = [];
+				$rawPermissions = $this->normalizePermissionsInput( $request->input( 'permissions', [] ) );
+				foreach ( $rawPermissions as $id => $permission ) {
+						$permissions[ $id ] = [
+								'showInDashboard' => $permission['showInDashboard'],
+								'showInCalendar'  => $permission['showInCalendar'],
+								'createItems'     => $permission['createItems'] ?? false,
+								'editItems'       => $permission['editItems'] ?? false,
+						];
+				}
+				$calendar->permissions = $this->sanitizePermissions( $permissions );
+
+				$calendar->save();
+
+				return response()->json( $calendar );
+		}
+
+		/**
+		 * Delete a calendar
+		 *
+		 * @param int $id The ID of the calendar to delete
+		 *
+		 * @return JsonResponse A JSON response indicating the deletion result
+		 * @throws Exception
+		 */
+		public function deleteCalendar( int $id ): JsonResponse {
+				$calendar = Calendar::find( $id );
+
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
+						//remove temporary ics file
+						$filename = $calendar->getTemporaryFile();
+						if ( file_exists( $filename ) ) {
+								unlink( $filename );
+						}
+				} else {
+						//remove all calendar items for this calendar
+						CalendarItem::where( 'calendar_id', $calendar->id )->delete();
+				}
+
+				$calendar->delete();
+
+				return response()->json( [ 'ok' => true, 'message' => 'Calendar deleted successfully' ] );
+		}
+
+
+		/**
+		 * Get events
+		 *
+		 * This method handles both date range queries and specific event ID lookups.
+		 * For event ID lookups on external calendars, it uses an optimized approach
+		 * that avoids loading unnecessary date ranges, improving performance for large calendars.
+		 *
+		 * @param Request $request The request containing either date range (start/end) or eventId
+		 *
+		 * @return JsonResponse Array of events matching the criteria
+		 * @throws Exception
+		 */
+		public function getEvents( Request $request ) {
+				// Special case: If looking for a specific event by ID
+				$eventId = $request->input( 'eventId' );
+				if ( $eventId ) {
+						try {
+								// Check if tables exist first
+								if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
+										return response()->json( [] );
+								}
+
+								$events    = [];
+								$calendars = Calendar::all();
+
+								foreach ( $calendars as $calendar ) {
+										if ( $calendar->enabled === false ) {
+												continue;
+										}
+										$permissions = $calendar->permissionsForCurrentUser();
+										if ( $permissions === null ) {
+												continue;
+										}
+										if ( $permissions['showInCalendar'] !== true ) {
+												continue;
+										}
+
+										// For normal calendars, try to find the specific event
+										if ( $calendar->type === 'normal' ) {
+												$event = CalendarItem::where( 'uid', $eventId )
+												                     ->orWhere( 'id', $eventId )
+												                     ->where( 'calendar_id', $calendar->id )
+												                     ->first();
+
+												if ( $event ) {
+														// Found the event, return it
+														$eventData = json_decode( $event->toJson(), true );
+
+														// Generate mapping for used custom fields
+														if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
+																$eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+																		$calendar->custom_fields,
+																		$eventData['custom_fields']
+																);
+														}
+
+														// Set default timezone
+														$defaultTimezone    = config( 'app.timezone' );
+														$eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+														$eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+
+														if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
+																$eventData['id'] = $eventData['uid'];
+														}
+														if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
+																$eventData['uid'] = $eventData['id'];
+														}
+														if ( empty( $eventData['title'] ) ) {
+																$eventData['title'] = '';
+														}
+
+														$events[] = $eventData;
+														break;
+												}
+										}
+
+										// For external calendars, use optimized single event lookup
+										if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
+												try {
+														// Use the new optimized method for finding a single event
+														$event = $calendar->findEventById( $eventId );
+
+														if ( $event ) {
+																// Found the event, prepare it for return
+																if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
+																		$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+																				$calendar->custom_fields,
+																				$event['custom_fields']
+																		);
+																}
+																$events[] = $event;
+																break;
+														}
+												} catch ( \Exception $e ) {
+														// Log and continue - we don't want a single calendar to break the entire request
+														\Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
+												}
+										}
+								}
+
+								// Restore timezones
+								$defaultTimezone = config( 'app.timezone' );
+								foreach ( $events as &$event ) {
+										$event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+										$event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+								}
+								unset( $event );
+
+								return response()->json( $events );
+						} catch ( \Exception $e ) {
+								// Log the error but return a valid response
+								\Log::error( 'Error in getEvents by ID: ' . $e->getMessage() );
+
+								return response()->json( [] );
+						}
+				}
+
+				try {
+						// Regular date range query
+						$request->validate( [
+								'start' => 'required|date',
+								'end'   => 'required|date',
+						] );
+
+						// Check if tables exist first
+						if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
+								return response()->json( [] );
+						}
+
+						$defaultTimezone = config( 'app.timezone' );
+
+						$start = ( new DateTimeImmutable( $request->input( 'start' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+						$end   = ( new DateTimeImmutable( $request->input( 'end' ), new DateTimeZone( $defaultTimezone ) ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+
+						$calendars = Calendar::all();
+						$events    = [];
+
+						foreach ( $calendars as $calendar ) {
+								if ( $calendar->enabled === false ) {
+										continue;
+								}
+								$permissions = $calendar->permissionsForCurrentUser();
+								if ( $permissions === null ) {
+										continue;
+								}
+								if ( $permissions['showInCalendar'] !== true ) {
+										continue;
+								}
+
+								try {
+										$calendarEvents = $calendar->events( $start, $end );
+										foreach ( $calendarEvents as $event ) {
+												// Generate mapping for used custom fields
+												if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
+														$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+																$calendar->custom_fields,
+																$event['custom_fields']
+														);
+												}
+												$events[] = $event;
+										}
+								} catch ( \Exception $e ) {
+										// Log and continue - we don't want a single calendar to break the entire request
+										\Log::error( 'Error fetching events from calendar ' . $calendar->id . ': ' . $e->getMessage() );
+								}
+						}
+
+						/**
+						 * Restore timezones
+						 */
+						foreach ( $events as &$event ) {
+								if ( empty( $event['id'] ) && ! empty( $event['uid'] ) ) {
+										$event['id'] = $event['uid'];
+								}
+								if ( empty( $event['uid'] ) && ! empty( $event['id'] ) ) {
+										$event['uid'] = $event['id'];
+								}
+								if ( empty( $event['title'] ) ) {
+										$event['title'] = '';
+								}
+
+								$event['start'] = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+								$event['end']   = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+						}
+						unset( $event );
+
+						return response()->json( $events );
+				} catch ( \Exception $e ) {
+						// Log the error but return a valid response
+						\Log::error( 'Error in getEvents date range: ' . $e->getMessage() );
+
+						return response()->json( [] );
+				}
+		}
+
+		/**
+		 * Update an event
+		 *
+		 * @param Request $request
+		 *
+		 * @return JsonResponse
+		 * @throws Exception
+		 */
+		public function updateEvent( Request $request ) {
+				try {
+						$validatedData = $request->validate( [
+								'uid'          => 'required',
+								'title'        => 'required',
+								'start'        => 'required|date',
+								'end'          => 'required|date|after:start',
+								'location'     => 'nullable',
+								'body'         => 'nullable',
+								'calendarId'   => 'required',
+								'customFields' => 'nullable',
+						] );
+				} catch ( Exception $e ) {
+						return response()->json( [ 'error' => $e->getMessage() ], 400 );
+				}
+
+				$calendar = Calendar::find( $validatedData['calendarId'] );
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				$customFieldsData      = $validatedData['customFields'] ?? [];
+				$customFields          = $calendar->custom_fields['fields'] ?? [];
+				$processedCustomFields = [];
+
+				foreach ( $customFields as $field ) {
+						$fieldId = 'custom_field_' . $field['id'];
+						if ( isset( $customFieldsData[ $fieldId ] ) ) {
+								$processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
+						} else if ( $field['required'] ) {
+								return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
+						}
+				}
+
+				if ( $calendar->type === 'normal' ) {
+						$calendarItem = CalendarItem::where( 'id', $validatedData['uid'] )->first();
+						if ( ! $calendarItem ) {
+								return response()->json( [ 'error' => 'Event not found' ], 404 );
+						}
+
+						$calendarItem->title    = $validatedData['title'];
+						$calendarItem->start    = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+						$calendarItem->end      = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+						$calendarItem->location = $validatedData['location'];
+						$calendarItem->body     = $validatedData['body'] ?? '';
+						if ( ! is_array( $calendarItem->custom_fields ) ) {
+								$calendarItem->custom_fields = [];
+						}
+						$calendarItem->custom_fields = array_merge( $calendarItem->custom_fields, $processedCustomFields );
+
+						$calendarItem->save();
+				} else if ( $calendar->type === 'caldav' ) {
+						$fullUrl = $calendar->custom_fields['url'] ?? '';
+
+						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
+						}
+
+						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+						$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+						$end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+
+						if ( isset( $customFieldsData['author_id'] ) ) {
+								$processedCustomFields['author_id'] = $customFieldsData['author_id'];
+						}
+						if ( isset( $customFieldsData['conversation_id'] ) ) {
+								$processedCustomFields['conversation_id'] = $customFieldsData['conversation_id'];
+						}
+
+						if ( count( $processedCustomFields ) > 0 ) {
+								if ( ! is_array( $validatedData['body'] ) ) {
+										$validatedData['body'] = [ 'body' => $validatedData['body'] ];
+								}
+
+								if ( ! isset( $validatedData['body']['custom_fields'] ) || ! is_array( $validatedData['body']['custom_fields'] ) ) {
+										$validatedData['body']['custom_fields'] = [];
+								}
+
+								$validatedData['body']['custom_fields'] = array_merge(
+										$validatedData['body']['custom_fields'],
+										$processedCustomFields
+								);
+
+								// Add mapping for used custom fields
+								$validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+										$calendar->custom_fields,
+										$processedCustomFields
+								);
+						}
+
+						$response = $caldavClient->updateEvent(
+								$remainingUrl,
+								$validatedData['uid'],
+								$validatedData['title'],
+								$validatedData['body'],
+								$start,
+								$end,
+								$validatedData['location']
+						);
+
+						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+								Log::error( 'Error updating event', $response );
+
+								return response()->json( [ 'error' => 'Error updating event' ], 500 );
+						}
+
+						$calendar->getExternalContent( true );
+				}
+
+				return response()->json( [ 'ok' => true, 'message' => 'Event updated successfully' ] );
+		}
+
+		/**
+		 * Generate a GUID
+		 * @return string
+		 */
+		private function GUID() {
+				if ( function_exists( 'com_create_guid' ) === true ) {
+						return trim( com_create_guid(), '{}' );
+				}
+
+				return sprintf( '%04X%04X-%04X-%04X-%04X-%04X%04X%04X', mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 16384, 20479 ), mt_rand( 32768, 49151 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ), mt_rand( 0, 65535 ) );
+		}
+
+		/**
+		 * Delete an event
+		 *
+		 * @param Request $request
+		 *
+		 * @return JsonResponse
+		 * @throws Exception
+		 */
+		public function deleteEvent( Request $request ) {
+				$eventId    = $request->input( 'id' );
+				$calendarId = $request->input( 'calendarId' );
+
+				$calendar = Calendar::find( $calendarId );
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				if ( $calendar->type === 'normal' ) {
+						$calendarItem = CalendarItem::where( 'id', $eventId )->first();
+						if ( ! $calendarItem ) {
+								return response()->json( [ 'error' => 'Event not found' ], 404 );
+						}
+						$calendarItem->delete();
+				} else if ( $calendar->type === 'caldav' ) {
+						$fullUrl = $calendar->custom_fields['url'] ?? '';
+
+						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
+						}
+
+						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+						$response = $caldavClient->deleteEvent( $remainingUrl, $eventId );
+						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+								Log::error( 'Error deleting event', $response );
+
+								return response()->json( [ 'error' => 'Error deleting event' ], 500 );
+						}
+						$calendar->getExternalContent( true );
+				}
+
+				return response()->json( [ 'ok' => true, 'message' => 'Event deleted successfully' ] );
+		}
+
+		/**
+		 * Helper function to generate custom field mapping
+		 *
+		 * @param array $customFields Array of all possible custom fields
+		 * @param array $usedCustomFields Array of used custom field values
+		 *
+		 * @return array Mapping of used custom field IDs to their names
+		 */
+		private function generateCustomFieldMapping( array $customFields, array $usedCustomFields ): array {
+				$mapping = [];
+				$fields  = $customFields['fields'] ?? [];
+
+				foreach ( $fields as $field ) {
+						$fieldId = 'custom_field_' . $field['id'];
+						// Only include fields that are actually used in the item
+						if ( isset( $usedCustomFields[ $fieldId ] ) ) {
+								$mapping[ $fieldId ] = $field['name'];
+						}
+				}
+
+				return $mapping;
+		}
+
+		/**
+		 * Create an event
+		 *
+		 * @param Request $request
+		 *
+		 * @return JsonResponse
+		 * @throws Exception
+		 */
+		public function createEvent( Request $request ) {
+				try {
+						$validatedData = $request->validate( [
+								'title'        => 'required',
+								'start'        => 'required|date',
+								'end'          => 'required|date',
+								'location'     => 'nullable',
+								'body'         => 'nullable',
+								'calendarId'   => 'required',
+								'customFields' => 'nullable',
+						] );
+				} catch ( Exception $e ) {
+						return response()->json( [ 'error' => $e->getMessage() ], 400 );
+				}
+
+				$calendar = Calendar::find( $validatedData['calendarId'] );
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				$userId = $this->requireAuthUserId();
+
+				$customFieldsData      = $validatedData['customFields'] ?? [];
+				$customFields          = $calendar->custom_fields['fields'] ?? [];
+				$processedCustomFields = [
+						'author_id' => $userId,
+				];
+
+				foreach ( $customFields as $field ) {
+						$fieldId = 'custom_field_' . $field['id'];
+						if ( isset( $customFieldsData[ $fieldId ] ) ) {
+								$processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
+						} else if ( $field['required'] ) {
+								return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
+						}
+				}
+
+				$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+				$end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+				if ( $start->getTimestamp() === $end->getTimestamp() ) {
+						$end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
+				}
+
+				$isAllDay = DateTimeRange::isAllDay( $start, $end );
+
+				if ( $calendar->type === 'normal' ) {
+						$calendarItem = new CalendarItem();
+
+						$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+						$calendarItem->author_id   = $userId;
+						$calendarItem->title       = $validatedData['title'] ?? 'Untitled Event';
+						$calendarItem->start       = $start ?? Carbon::now();
+						$calendarItem->end         = $end ?? Carbon::now()->addHour();
+						$calendarItem->is_all_day  = $isAllDay ?? false;
+									$calendarItem->is_private  = false;
+									$calendarItem->is_read_only = false;
+									$calendarItem->state       = 'active';
+						$calendarItem->is_private  = $validatedData['is_private'] ?? false;
+						$calendarItem->state       = $validatedData['state'] ?? 'active';
+
+						$calendarItem->location      = $validatedData['location'] ?? '';
+						$calendarItem->body          = $validatedData['body'] ?? '';
+						$calendarItem->custom_fields = $processedCustomFields ?? [];
+
+						$calendarItem->save();
+				} else if ( $calendar->type === 'caldav' ) {
+						$fullUrl = $calendar->custom_fields['url'] ?? '';
+
+						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
+						}
+
+						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+						$uid = $this->GUID();
+
+						if ( ! is_array( $validatedData['body'] ) ) {
+								$validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
+						}
+
+						$validatedData['body']['custom_fields'] = $processedCustomFields;
+
+						// Add mapping for used custom fields
+						$validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+								$calendar->custom_fields,
+								$processedCustomFields
+						);
+
+						$response = $caldavClient->createEvent(
+								$remainingUrl,
+								$uid,
+								$validatedData['title'],
+								$validatedData['body'],
+								$start,
+								$end,
+								$isAllDay,
+								$validatedData['location']
+						);
+
+						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+								Log::error( 'Error creating event', $response );
+
+								return response()->json( [ 'error' => 'Error creating event' ], 500 );
+						}
+
+						$calendar->getExternalContent( true );
+				}
+
+				return response()->json( [ 'ok' => true, 'message' => 'Event created successfully' ] );
+		}
+
+		private function processTemplate(
+				string        $template,
+				?Conversation $conversation,
+				Calendar      $calendar,
+				array         $customFields = []
+		): string {
+				if ( ! $conversation ) {
+						return $template;
+				}
+
+				$result = str_replace( '{{title}}', $conversation->subject, $template );
+
+				// Get the field name mapping from calendar's custom fields configuration
+				$fieldMapping = [];
+
+				if ( ! empty( $calendar->custom_fields['fields'] ) ) {
+						foreach ( $calendar->custom_fields['fields'] as $field ) {
+								$fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
+						}
+				}
+
+				// Process custom fields using the mapping
+				foreach ( $customFields as $fieldId => $value ) {
+						if ( is_array( $value ) ) {
+								$value = implode( ', ', $value );
+						}
+
+						if ( isset( $fieldMapping[ $fieldId ] ) ) {
+								$fieldName = $fieldMapping[ $fieldId ];
+								$result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
+						}
+				}
+
+
+
+				$result = str_replace( '{{title}}', $conversation->subject, $template );
+
+				// Get the field name mapping from calendar's custom fields configuration
+				$fieldMapping = [];
+
+				if ( ! empty( $calendar->custom_fields['fields'] ) ) {
+						foreach ( $calendar->custom_fields['fields'] as $field ) {
+								$fieldMapping[ 'custom_field_' . $field['id'] ] = $field['name'];
+						}
+				}
+
+				// Process custom fields using the mapping
+				foreach ( $customFields as $fieldId => $value ) {
+						if ( is_array( $value ) ) {
+								$value = implode( ', ', $value );
+						}
+
+						if ( isset( $fieldMapping[ $fieldId ] ) ) {
+								$fieldName = $fieldMapping[ $fieldId ];
+								$result    = str_replace( '{{' . $fieldName . '}}', $value ?? '', $result );
+						}
+				}
+
+				return $result;
+		}
+
+
+		/**
+		 * Create an event from a conversation
+		 *
+		 * @param int $conversation
+		 * @param Request $request
+		 *
+		 * @return JsonResponse
+		 * @throws Exception
+		 */
+		public function createEventFromConversation( int $conversation, Request $request ) {
+				try {
+						$validatedData = $request->validate( [
+								'title'        => 'required|nullable',
+								'start'        => 'required|date',
+								'end'          => 'required|date|after:start',
+								'location'     => 'nullable',
+								'body'         => 'nullable',
+								'calendarId'   => 'required',
+								'customFields' => 'nullable',
+						] );
+				} catch ( Exception $e ) {
+						return response()->json( [ 'error' => $e->getMessage() ], 400 );
+				}
+
+				$calendar = Calendar::find( $validatedData['calendarId'] );
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				$userId = $this->requireAuthUserId();
+
+				$conversationObj = Conversation::find( $conversation );
+
+				$start = ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+				$end   = ( new DateTimeImmutable( $validatedData['end'] ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+				if ( $start->getTimestamp() === $end->getTimestamp() ) {
+						$end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
+				}
+				$isAllDay = DateTimeRange::isAllDay( $start, $end );
+
+				$customFieldsData      = $validatedData['customFields'] ?? [];
+				$customFields          = $calendar->custom_fields['fields'] ?? [];
+				$processedCustomFields = [];
+
+				foreach ( $customFields as $field ) {
+						$fieldId = 'custom_field_' . $field['id'];
+						if ( isset( $customFieldsData[ $fieldId ] ) ) {
+								$processedCustomFields[ $fieldId ] = $customFieldsData[ $fieldId ];
+						} else if ( $field['required'] ) {
+								return response()->json( [ 'error' => 'Required custom field missing: ' . $field['name'] ], 400 );
+						}
+				}
+
+				if ( empty( $calendar->title_template ) ) {
+						$calendar->title_template = $request->input( 'title' );
+				}
+
+				$uid = null;
+				if ( $calendar->type === 'normal' ) {
+						$calendarItem = new CalendarItem();
+
+						$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+						$calendarItem->author_id   = $userId;
+						$calendarItem->title       = $this->processTemplate(
+								$calendar->title_template,
+								$conversationObj,
+								$calendar,
+								$processedCustomFields ?? []
+						);
+						$calendarItem->start       = $start ?? Carbon::now();
+						$calendarItem->end         = $end ?? Carbon::now()->addHour();
+						$calendarItem->is_all_day  = $isAllDay ?? false;
+									$calendarItem->is_private  = false;
+									$calendarItem->is_read_only = false;
+									$calendarItem->state       = 'active';
+						$calendarItem->is_private  = false;
+						$calendarItem->state       = 'active';
+						$calendarItem->location    = $validatedData['location'] ?? '';
+						$calendarItem->body        = $validatedData['body'] ?? '';
+
+						// Merge all custom fields safely
+						$customFields = $calendarItem->custom_fields;
+						if ( ! is_array( $customFields ) ) {
+								$customFields = [];
+						}
+
+						$mergedCustomFields = array_merge(
+								$customFields,
+								[
+										'conversation_id' => $conversation,
+										'author_id'       => $userId,
+								],
+								$processedCustomFields ?? []
+						);
+
+						$calendarItem->custom_fields = $mergedCustomFields;
+
+						$calendarItem->save();
+						$uid = $calendarItem->id;
+				} else if ( $calendar->type === 'caldav' ) {
+						$fullUrl = $calendar->custom_fields['url'] ?? '';
+
+						if ( ! is_string( $fullUrl ) || $fullUrl === '' ) {
+								return response()->json( [
+										'status'  => 'error',
+										'message' => 'CalDAV calendar is not properly configured (missing URL).',
+								], 422 );
+						}
+
+						$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+						$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+						$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+						$uid = $this->GUID();
+
+						if ( ! is_array( $validatedData['body'] ) ) {
+								$validatedData['body'] = [ 'body' => empty( $validatedData['body'] ) ? '-' : $validatedData['body'] ];
+						}
+
+						// Merge all custom fields
+						$mergedCustomFields = array_merge( [
+								'conversation_id' => $conversation,
+								'author_id'       => $userId,
+						], $processedCustomFields );
+
+						$validatedData['body']['custom_fields'] = $mergedCustomFields;
+
+						// Add mapping for used custom fields
+						$validatedData['body']['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+								$calendar->custom_fields,
+								$mergedCustomFields
+						);
+
+						$response = $caldavClient->createEvent(
+								$remainingUrl,
+								$uid,
+								$this->processTemplate( $calendar->title_template, Conversation::find( $conversation ), $calendar, $processedCustomFields ),
+								$validatedData['body'],
+								$start,
+								$end,
+								$isAllDay,
+								$validatedData['location']
+						);
+
+						if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+								Log::error( 'Error creating event', $response );
+
+								return response()->json( [ 'error' => 'Error creating event' ], 500 );
+						}
+
+						$calendar->getExternalContent( true );
+				}
+
+				if ( $uid !== null ) {
+						$conversation = Conversation::find( $conversation );
+						if ( $conversation !== null ) {
+								$action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
+								$created_by_user_id = $userId;
+
+								// Store the event UID for better permalink support
+								$meta = [
+										'calendar_item_id' => $uid,
+										'calendar_id'      => $calendar->id,
+										'calendar_type'    => $calendar->type,
+										'start'            => ( new DateTimeImmutable( $validatedData['start'] ) )->setTimezone( new DateTimeZone( 'UTC' ) )->format( DATE_ATOM ),
+								];
+
+								// For external calendars, also store the event UID
+								if ( $calendar->type === 'caldav' || $calendar->type === 'ics' ) {
+										$meta['event_uid'] = $uid;
+								}
+
+								Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
+										'user_id'            => $conversation->user_id,
+										'created_by_user_id' => $created_by_user_id,
+										'action_type'        => $action_type,
+										'source_via'         => Thread::PERSON_USER,
+										'source_type'        => Thread::SOURCE_TYPE_WEB,
+										'meta'               => $meta,
+								] );
+						}
+				}
+
+				return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
+		}
+
+		/**
+		 * Get a calendar
+		 *
+		 * @param int $id
+		 *
+		 * @return JsonResponse
+		 */
+		public function getCalendar( $id ) {
+				$calendar = Calendar::find( $id );
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				// Ensure we never return stale principals to the settings UI
+				$clean = $this->sanitizePermissions( $calendar->permissions );
+				if ( $clean !== ( $calendar->permissions ?? [] ) ) {
+					$calendar->permissions = $clean;
+					$calendar->save();
+				}
+
+				return response()->json( $calendar );
+		}
+
+		/**
+		 * Get a single event by ID - optimized endpoint for permalinks
+		 *
+		 * @param string $eventId The event ID to retrieve
+		 *
+		 * @return JsonResponse
+		 */
+		public function getEventById( string $eventId ): JsonResponse {
+				try {
+						// Check if tables exist first
+						if ( ! \Schema::hasTable( 'calendars' ) || ! \Schema::hasTable( 'calendar_items' ) ) {
+								return response()->json( [ 'error' => 'Calendar module not properly initialized' ], 500 );
+						}
+
+						$calendars = Calendar::all();
+
+						foreach ( $calendars as $calendar ) {
+								if ( $calendar->enabled === false ) {
+										continue;
+								}
+
+								$permissions = $calendar->permissionsForCurrentUser();
+								if ( $permissions === null || ! $permissions['showInCalendar'] ) {
+										continue;
+								}
+
+								// For normal calendars, try to find the specific event by ID only
+								if ( $calendar->type === 'normal' ) {
+										$event = CalendarItem::where( 'calendar_id', $calendar->id )
+										                     ->where( 'id', $eventId )
+										                     ->first();
+
+										if ( $event ) {
+												$eventData = json_decode( $event->toJson(), true );
+
+												// Ensure calendar ID is present
+												$eventData['calendarId'] = $calendar->id;
+
+												// Generate mapping for used custom fields
+												if ( isset( $eventData['custom_fields'] ) && is_array( $eventData['custom_fields'] ) ) {
+														$eventData['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+																$calendar->custom_fields,
+																$eventData['custom_fields']
+														);
+												}
+
+												// Set default timezone
+												$defaultTimezone    = config( 'app.timezone' );
+												$eventData['start'] = ( new DateTimeImmutable( $eventData['start'], new DateTimeZone( 'UTC' ) ) )
+														->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+												$eventData['end']   = ( new DateTimeImmutable( $eventData['end'], new DateTimeZone( 'UTC' ) ) )
+														->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+
+												// Ensure IDs are set
+												if ( empty( $eventData['id'] ) && ! empty( $eventData['uid'] ) ) {
+														$eventData['id'] = $eventData['uid'];
+												}
+												if ( empty( $eventData['uid'] ) && ! empty( $eventData['id'] ) ) {
+														$eventData['uid'] = $eventData['id'];
+												}
+												if ( empty( $eventData['title'] ) ) {
+														$eventData['title'] = '';
+												}
+
+												return response()->json( $eventData );
+										}
+								}
+
+								// For external calendars, use optimized single event lookup
+								if ( $calendar->type === 'ics' || $calendar->type === 'caldav' ) {
+										try {
+												$event = $calendar->findEventById( $eventId );
+
+												if ( $event ) {
+														// Add calendar ID to the event data
+														$event['calendarId']  = $calendar->id;
+														$event['calendar_id'] = $calendar->id;
+
+														// Generate mapping for used custom fields
+														if ( isset( $event['custom_fields'] ) && is_array( $event['custom_fields'] ) ) {
+																$event['custom_fields_mapping'] = $this->generateCustomFieldMapping(
+																		$calendar->custom_fields,
+																		$event['custom_fields']
+																);
+														}
+
+														// Ensure timezone conversion is done
+														$defaultTimezone = config( 'app.timezone' );
+														$event['start']  = ( new DateTimeImmutable( $event['start'], new DateTimeZone( 'UTC' ) ) )
+																->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+														$event['end']    = ( new DateTimeImmutable( $event['end'], new DateTimeZone( 'UTC' ) ) )
+																->setTimezone( new DateTimeZone( $defaultTimezone ) )->format( 'Y-m-d H:i:s' );
+
+														return response()->json( $event );
+												}
+										} catch ( \Exception $e ) {
+												// Log and continue checking other calendars
+												\Log::error( 'Error fetching event from external calendar: ' . $e->getMessage() );
+										}
+								}
+						}
+
+						// Event not found in any calendar
+						return response()->json( [ 'error' => 'Event not found' ], 404 );
+
+				} catch ( \Exception $e ) {
+						\Log::error( 'Error in getEventById: ' . $e->getMessage() );
+
+						return response()->json( [ 'error' => 'Failed to retrieve event' ], 500 );
+				}
+		}
+
+		/**
+		 * Create an event from an attachment
+		 *
+		 * @param Request $request
+		 *
+		 * @return JsonResponse
+		 * @throws Exception
+		 */
+		public function createEventFromAttachment( Request $request ) {
+				try {
+						$validatedData = $request->validate( [
+								'attachmentId'   => 'required',
+								'conversationId' => 'required',
+								'calendarId'     => 'required',
+						] );
+				} catch ( Exception $e ) {
+						return response()->json( [ 'error' => $e->getMessage() ], 400 );
+				}
+
+				$calendar = Calendar::find( $validatedData['calendarId'] );
+				if ( ! $calendar ) {
+						return response()->json( [ 'error' => 'Calendar not found' ], 404 );
+				}
+
+				$userId = $this->requireAuthUserId();
+
+				$conversation = Conversation::find( $validatedData['conversationId'] );
+				if ( ! $conversation ) {
+						return response()->json( [ 'error' => 'Conversation not found' ], 404 );
+				}
+
+				$attachment = Attachment::find( $validatedData['attachmentId'] );
+				if ( ! $attachment ) {
+						return response()->json( [ 'error' => 'Attachment not found' ], 404 );
+				}
+				$file = $attachment->getLocalFilePath();
+
+				$ical = new ICal( $file );
+				/** @var Event[] $events */
+				$events = $ical->events();
+
+				$refetchCalendarIds = [];
+
+				//add conversation url to body
+				$conversationUrl = route( 'conversations.view', [ 'id' => $conversation->id ] );
+
+				foreach ( $events as $event ) {
+						$start = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtstart_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
+						if ( ! empty( $event->dtend ) ) {
+								$end = DateTimeImmutable::createFromMutable( $ical->iCalDateToDateTime( $event->dtend_array[3] )->setTimezone( new DateTimeZone( 'UTC' ) ) );
+						} else {
+								if ( ! empty( $event->duration ) ) {
+										$end = $start->add( new DateInterval( $event->duration ) );
+								} else {
+										$end = $start->add( new DateInterval( 'PT1H' ) );
+								}
+						}
+						if ( $start->getTimestamp() === $end->getTimestamp() ) {
+								$end = $start->add( new DateInterval( 'P1D' ) )->sub( new DateInterval( 'PT1S' ) );
+						}
+						$isAllDay = DateTimeRange::isAllDay( $start, $end );
+
+						if ( $calendar->type === 'normal' ) {
+								$calendarItem = new CalendarItem();
+
+								$calendarItem->calendar_id = $validatedData['calendarId'] ?? null;
+								$calendarItem->author_id   = $userId;
+								$calendarItem->title       = $event->summary ?? 'Untitled Event';
+								$calendarItem->start       = $start ?? Carbon::now();
+								$calendarItem->end         = $end ?? Carbon::now()->addHour();
+								$calendarItem->is_all_day  = $isAllDay ?? false;
+									$calendarItem->is_private  = false;
+									$calendarItem->is_read_only = false;
+									$calendarItem->state       = 'active';
+								$calendarItem->location    = $event->location ?? '';
+								$calendarItem->body        = $event->description ?? '';
+
+								// Merge custom fields safely
+								$customFields = $calendarItem->custom_fields;
+								if ( ! is_array( $customFields ) ) {
+										$customFields = [];
+								}
+
+								$customFields['conversation_id'] = $conversation ? $conversation->id : null;
+								$customFields['author_id']       = $userId;
+
+								$calendarItem->custom_fields = $customFields;
+
+								$calendarItem->save();
+								$uid = $calendarItem->id;
+						} else if ( $calendar->type === 'caldav' ) {
+								$fullUrl      = $calendar->custom_fields['url'];
+								$baseUrl      = substr( $fullUrl, 0, strpos( $fullUrl, '/', 8 ) );
+								$remainingUrl = substr( $fullUrl, strpos( $fullUrl, '/', 8 ) );
+								$caldavClient = new CalDAV( $baseUrl, $calendar->custom_fields['username'], $calendar->custom_fields['password'] );
+
+								$uid = $event->uid ?? $this->GUID();
+
+								$description = [
+										'body'          => empty( $event->description ) ? '-' : $event->description,
+										'custom_fields' => [
+												'conversation_id' => $conversation->id,
+												'author_id'       => $userId,
+										],
+								];
+
+								$response = $caldavClient->createEvent( $remainingUrl, $uid, $event->summary, $description, $start, $end, $isAllDay, $event->location );
+								if ( $response['statusCode'] < 200 || $response['statusCode'] > 300 ) {
+										Log::error( 'Error creating event', $response );
+
+										return response()->json( [ 'error' => 'Error creating event', $response['body'], 'data' => [ $uid, $event->summary, $description, $start, $end, $event->location ] ], 500 );
+								}
+								$refetchCalendarIds[] = $calendar->id;
+						}
+
+						if ( $uid !== null ) {
+								$action_type        = CalendarItem::ACTION_TYPE_ADD_TO_CALENDAR;
+								$created_by_user_id = $userId;
+								Thread::create( $conversation, Thread::TYPE_LINEITEM, '', [
+										'user_id'            => $conversation->user_id,
+										'created_by_user_id' => $created_by_user_id,
+										'action_type'        => $action_type,
+										'source_via'         => Thread::PERSON_USER,
+										'source_type'        => Thread::SOURCE_TYPE_WEB,
+										'meta'               => [
+												'calendar_item_id' => $uid,
+												'calendar_id'      => $calendar->id,
+												'start'            => $start->format( DATE_ATOM ),
+										],
+								] );
+						}
+				}
+
+				$refetchCalendarIds = array_values( array_unique( $refetchCalendarIds ) );
+				foreach ( $refetchCalendarIds as $refetchCalendarId ) {
+						UpdateExternalCalendarJob::dispatch( $refetchCalendarId );
+				}
+
+				return response()->json( [ 'status' => 'success', 'ok' => true, 'message' => 'Event created successfully' ] );
+		}
 
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "LJPc calendar module",
   "alias": "ljpccalendarmodule",
   "description": "This module adds a calendar to Freescout with support for external ICS and CalDAV calendars!",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "detailsUrl": "",
   "author": "LJPc solutions",
   "authorUrl": "https://ljpc.solutions",


### PR DESCRIPTION
When receiving an email with teams calendar booked meeting (ICS) or other, tempting to book it via conversation calendar event icon would cause an error. I took the liberty to get the https://freescout.net/module/teams/ Teams Module compatibility & did some minor fixes

For short: Team module (Users) once deleted or created, on an already existing calendar, will no longer be valid for permission adjustment.

- Normalize and sanitize calendar permissions before saving

- Prevent user/team ID collisions by introducing canonical team principal keys (t: prefix)

- Remove stale permissions for deleted teams or inactive users

- Improve Teams module compatibility and principal validation logic

- Harden API controller against malformed permission payloads

 -Add migrations to fix boolean defaults on calendar_items (From previous hotfix)

 - Ensure calendar_items.state has consistent default (active) and backfill null values
